### PR TITLE
migrate to epaper-dithering v4 API

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "pillow>=10.0.0",
     "numpy>=1.24.0,!=2.4.0",
     "bleak-retry-connector>=3.5.0",
-    "epaper-dithering==0.6.4",
+    "epaper-dithering==4.0.0",
     "cryptography>=41.0.0",
 ]
 
@@ -85,8 +85,8 @@ argument-rgx = "^[a-zA-Z_][a-zA-Z0-9_]*$"
 attr-rgx = "^[a-zA-Z_][a-zA-Z0-9_]*$"
 
 [tool.pylint.design]
-max-args = 12
-max-positional-arguments = 12
+max-args = 16
+max-positional-arguments = 16
 max-locals = 28              # _build_info_tree renders a complex tree with many conditional vars
 max-attributes = 22          # config dataclasses have many fields by nature
 max-branches = 25

--- a/src/opendisplay/cli.py
+++ b/src/opendisplay/cli.py
@@ -94,16 +94,16 @@ def _parse_hex_key(hex_str: str | None) -> bytes | None:
         _error(f"--key contains invalid hex characters: {exc}")
 
 
-def _parse_tone_compression(value: str) -> float | str:
-    """Parse tone compression value: 'auto' or a float in [0.0, 1.0]."""
-    if value == "auto":
-        return "auto"
+def _parse_compression_value(flag: str, value: str) -> float | str:
+    """Parse a compression knob value: 'auto'/'off' or a float in [0.0, 1.0]."""
+    if value in ("auto", "off"):
+        return value
     try:
         f = float(value)
     except ValueError:
-        _error(f'--tone-compression must be "auto" or a float, got {value!r}')
+        _error(f'{flag} must be "auto", "off", or a float, got {value!r}')
     if not 0.0 <= f <= 1.0:
-        _error(f"--tone-compression must be between 0.0 and 1.0, got {f}")
+        _error(f"{flag} must be between 0.0 and 1.0, got {f}")
     return f
 
 
@@ -501,18 +501,34 @@ def _add_upload_parser(subparsers: argparse._SubParsersAction[argparse.ArgumentP
         help="Additional image rotation in degrees on top of device config (default: 0)",
     )
     p.add_argument("--no-compress", action="store_true", help="Disable zlib compression")
+    p.add_argument("--no-serpentine", action="store_true", help="Disable serpentine scan direction")
+    p.add_argument("--exposure", type=float, default=1.0, metavar="VALUE", help="Exposure multiplier (default: 1.0)")
     p.add_argument(
-        "--tone-compression",
+        "--saturation", type=float, default=1.0, metavar="VALUE", help="Saturation multiplier (default: 1.0)"
+    )
+    p.add_argument("--shadows", type=float, default=0.0, metavar="VALUE", help="Shadow lift 0.0–1.0 (default: 0.0)")
+    p.add_argument(
+        "--highlights", type=float, default=0.0, metavar="VALUE", help="Highlight rolloff 0.0–1.0 (default: 0.0)"
+    )
+    p.add_argument(
+        "--tone",
         default="auto",
         metavar="VALUE",
-        help='Dynamic range compression: "auto" or 0.0–1.0 (default: auto)',
+        help='Tone compression: "auto", "off", or 0.0–1.0 (default: auto)',
+    )
+    p.add_argument(
+        "--gamut",
+        default="auto",
+        metavar="VALUE",
+        help='Gamut compression: "auto", "off", or 0.0–1.0 (default: auto)',
     )
     p.set_defaults(func=_cmd_upload)
 
 
 def _cmd_upload(args: argparse.Namespace) -> None:
     key = _parse_hex_key(args.key)
-    tone = _parse_tone_compression(args.tone_compression)
+    tone = _parse_compression_value("--tone", args.tone)
+    gamut = _parse_compression_value("--gamut", args.gamut)
     _run(
         _upload(
             _device_kwargs(args.device, key, args.timeout),
@@ -522,7 +538,13 @@ def _cmd_upload(args: argparse.Namespace) -> None:
             _FIT_CHOICES[args.fit],
             _ROTATE_CHOICES[args.rotate],
             not args.no_compress,
+            not args.no_serpentine,
+            args.exposure,
+            args.saturation,
+            args.shadows,
+            args.highlights,
             tone,
+            gamut,
         )
     )
 
@@ -535,7 +557,13 @@ async def _upload(
     fit: FitMode,
     rotate: Rotation,
     compress: bool,
-    tone_compression: float | str,
+    serpentine: bool,
+    exposure: float,
+    saturation: float,
+    shadows: float,
+    highlights: float,
+    tone: float | str,
+    gamut: float | str,
 ) -> None:
     try:
         image = Image.open(image_path)
@@ -588,7 +616,13 @@ async def _upload(
                     refresh_mode=refresh_mode,
                     dither_mode=dither_mode,
                     compress=compress,
-                    tone_compression=tone_compression,
+                    serpentine=serpentine,
+                    exposure=exposure,
+                    saturation=saturation,
+                    shadows=shadows,
+                    highlights=highlights,
+                    tone=tone,
+                    gamut=gamut,
                     fit=fit,
                     rotate=rotate,
                     progress_callback=on_progress,

--- a/src/opendisplay/device.py
+++ b/src/opendisplay/device.py
@@ -121,7 +121,13 @@ def prepare_image(
     panel_ic_type: int | None = None,
     dither_mode: DitherMode = DitherMode.BURKES,
     compress: bool = True,
-    tone_compression: float | str = "auto",
+    serpentine: bool = True,
+    exposure: float = 1.0,
+    saturation: float = 1.0,
+    shadows: float = 0.0,
+    highlights: float = 0.0,
+    tone: float | str = "auto",
+    gamut: float | str = "auto",
     fit: FitMode = FitMode.CONTAIN,
     rotate: Rotation = Rotation.ROTATE_0,
 ) -> tuple[bytes, bytes | None, Image.Image]:
@@ -141,7 +147,13 @@ def prepare_image(
             from config.
         dither_mode: Dithering algorithm to use (default: BURKES)
         compress: Whether to compress the image data (default: True)
-        tone_compression: Dynamic range compression ("auto", or 0.0-1.0)
+        serpentine: Alternate scan direction each row to reduce artifacts (default: True)
+        exposure: Exposure multiplier, >1.0 brightens (default: 1.0)
+        saturation: Saturation multiplier, >1.0 boosts (default: 1.0)
+        shadows: Shadow lift in [0.0, 1.0] (default: 0.0)
+        highlights: Highlight rolloff in [0.0, 1.0] (default: 0.0)
+        tone: Dynamic range compression — "auto", "off", or 0.0–1.0 (default: "auto")
+        gamut: Gamut compression — "auto", "off", or 0.0–1.0 (default: "auto")
         fit: How to map the image to display dimensions (default: CONTAIN)
         rotate: Source image rotation enum (0/90/180/270)
 
@@ -190,7 +202,18 @@ def prepare_image(
         )
 
     palette = get_palette_for_display(panel_ic_type, color_scheme, use_measured_palettes)
-    dithered = dither_image(image, palette, mode=dither_mode, tone_compression=tone_compression)
+    dithered = dither_image(
+        image,
+        palette,
+        mode=dither_mode,
+        serpentine=serpentine,
+        exposure=exposure,
+        saturation=saturation,
+        shadows=shadows,
+        highlights=highlights,
+        tone=tone,
+        gamut=gamut,
+    )
 
     # Encode to device format
     if color_scheme in (ColorScheme.BWR, ColorScheme.BWY):
@@ -843,7 +866,13 @@ class OpenDisplayDevice:
         image: Image.Image,
         dither_mode: DitherMode,
         compress: bool,
-        tone_compression: float | str = "auto",
+        serpentine: bool = True,
+        exposure: float = 1.0,
+        saturation: float = 1.0,
+        shadows: float = 0.0,
+        highlights: float = 0.0,
+        tone: float | str = "auto",
+        gamut: float | str = "auto",
         fit: FitMode = FitMode.CONTAIN,
         rotate: Rotation = Rotation.ROTATE_0,
     ) -> tuple[bytes, bytes | None, Image.Image]:
@@ -857,7 +886,13 @@ class OpenDisplayDevice:
             panel_ic_type=panel_ic_type,
             dither_mode=dither_mode,
             compress=compress,
-            tone_compression=tone_compression,
+            serpentine=serpentine,
+            exposure=exposure,
+            saturation=saturation,
+            shadows=shadows,
+            highlights=highlights,
+            tone=tone,
+            gamut=gamut,
             fit=fit,
             rotate=rotate,
         )
@@ -868,7 +903,13 @@ class OpenDisplayDevice:
         refresh_mode: RefreshMode = RefreshMode.FULL,
         dither_mode: DitherMode = DitherMode.BURKES,
         compress: bool = True,
-        tone_compression: float | str = "auto",
+        serpentine: bool = True,
+        exposure: float = 1.0,
+        saturation: float = 1.0,
+        shadows: float = 0.0,
+        highlights: float = 0.0,
+        tone: float | str = "auto",
+        gamut: float | str = "auto",
         fit: FitMode = FitMode.CONTAIN,
         rotate: Rotation = Rotation.ROTATE_0,
         progress_callback: Callable[[int, int], None] | None = None,
@@ -887,7 +928,13 @@ class OpenDisplayDevice:
             refresh_mode: Display refresh mode (default: FULL)
             dither_mode: Dithering algorithm (default: BURKES)
             compress: Enable zlib compression (default: True)
-            tone_compression: Dynamic range compression ("auto" or 0.0–1.0, default: "auto").
+            serpentine: Alternate scan direction each row to reduce artifacts (default: True)
+            exposure: Exposure multiplier, >1.0 brightens (default: 1.0)
+            saturation: Saturation multiplier, >1.0 boosts (default: 1.0)
+            shadows: Shadow lift in [0.0, 1.0] (default: 0.0)
+            highlights: Highlight rolloff in [0.0, 1.0] (default: 0.0)
+            tone: Dynamic range compression — "auto", "off", or 0.0–1.0 (default: "auto")
+            gamut: Gamut compression — "auto", "off", or 0.0–1.0 (default: "auto")
             fit: How to map the image to display dimensions (default: CONTAIN).
             rotate: Source image rotation enum, applied before fit/encoding.
 
@@ -915,7 +962,18 @@ class OpenDisplayDevice:
 
         # Prepare image (fit, dither, encode, compress)
         image_data, compressed_data, processed_image = self._prepare_image(
-            image, dither_mode, compress and supports_compression, tone_compression, fit, rotate
+            image,
+            dither_mode,
+            compress and supports_compression,
+            serpentine=serpentine,
+            exposure=exposure,
+            saturation=saturation,
+            shadows=shadows,
+            highlights=highlights,
+            tone=tone,
+            gamut=gamut,
+            fit=fit,
+            rotate=rotate,
         )
         await self._dispatch_upload(image_data, refresh_mode, compress, compressed_data, progress_callback)
 

--- a/tests/unit/test_device_upload_rotation.py
+++ b/tests/unit/test_device_upload_rotation.py
@@ -83,7 +83,9 @@ def _stub_prepare_pipeline(monkeypatch: pytest.MonkeyPatch) -> None:
     )
     monkeypatch.setattr(
         "opendisplay.device.dither_image",
-        lambda image, palette, mode, tone_compression: image.convert("P"),
+        lambda image, palette, *, mode, serpentine, exposure, saturation, shadows, highlights, tone, gamut: (
+            image.convert("P")
+        ),
     )
     monkeypatch.setattr(
         "opendisplay.device.encode_image",


### PR DESCRIPTION
Pin epaper-dithering to 4.0.0 and surface the full v4 dither_image signature (serpentine, exposure, saturation, shadows, highlights, tone, gamut) across prepare_image(), upload_image(), and the CLI upload subcommand. Renames tone_compression → tone throughout.