### PR TITLE
Add touch event parsing and TouchTracker to advertisement module

### DIFF
--- a/src/opendisplay/__init__.py
+++ b/src/opendisplay/__init__.py
@@ -25,6 +25,9 @@ from .models.advertisement import (
     AdvertisementTracker,
     ButtonChangeEvent,
     ButtonEventData,
+    TouchChangeEvent,
+    TouchEventData,
+    TouchTracker,
     decode_button_event,
     parse_advertisement,
 )
@@ -105,6 +108,9 @@ __all__ = [
     "AdvertisementTracker",
     "ButtonEventData",
     "ButtonChangeEvent",
+    "TouchEventData",
+    "TouchChangeEvent",
+    "TouchTracker",
     # Enums
     "ColorScheme",
     "DitherMode",

--- a/src/opendisplay/models/advertisement.py
+++ b/src/opendisplay/models/advertisement.py
@@ -83,6 +83,30 @@ class AdvertisementData:
             return []
         return [decode_button_event(raw, i) for i, raw in enumerate(self.dynamic_data)]
 
+    def touch_event(self, start_byte: int) -> TouchEventData | None:
+        """Parse a 5-byte touch block from dynamic_data at the given offset (v1 only).
+
+        Args:
+            start_byte: Offset within the 11-byte dynamic return block (0–6).
+
+        Returns:
+            Parsed touch data, or None if not a v1 advertisement or block out of range.
+        """
+        if self.format_version != "v1":
+            return None
+        if start_byte + 5 > len(self.dynamic_data):
+            return None
+        byte0 = self.dynamic_data[start_byte]
+        x = struct.unpack_from("<H", self.dynamic_data, start_byte + 1)[0]
+        y = struct.unpack_from("<H", self.dynamic_data, start_byte + 3)[0]
+        return TouchEventData(
+            start_byte=start_byte,
+            contact_count=byte0 & 0x0F,
+            track_id=(byte0 >> 4) & 0x0F,
+            x=x,
+            y=y,
+        )
+
 
 @dataclass(frozen=True)
 class ButtonEventData:
@@ -108,6 +132,45 @@ class ButtonChangeEvent:
     previous_press_count: int
     raw: int
     previous_raw: int
+    timestamp: float
+
+
+@dataclass(frozen=True)
+class TouchEventData:
+    """Decoded touch data from a 5-byte block in v1 dynamic return data."""
+
+    start_byte: int
+    contact_count: int
+    track_id: int
+    x: int
+    y: int
+
+    @property
+    def event_type(self) -> str:
+        """Return event type string for the current contact state."""
+        if 1 <= self.contact_count <= 5:
+            return "touch_down"
+        if self.contact_count == 6:
+            return "touch_up"
+        return "touch_idle"
+
+    @property
+    def is_touching(self) -> bool:
+        """Return True when one or more contacts are active."""
+        return 1 <= self.contact_count <= 5
+
+
+@dataclass(frozen=True)
+class TouchChangeEvent:
+    """Touch state transition emitted by TouchTracker."""
+
+    address: str
+    instance: int
+    event_type: str
+    x: int
+    y: int
+    contact_count: int
+    track_id: int
     timestamp: float
 
 
@@ -213,6 +276,71 @@ class AdvertisementTracker:
                 )
 
         return events
+
+
+class TouchTracker:
+    """Track per-device v1 touch state and emit touch transitions.
+
+    One instance per touch controller; pass the controller's instance_number
+    and touch_data_start_byte from GlobalConfig.touch_controllers[i].
+    """
+
+    def __init__(self, instance: int, start_byte: int) -> None:
+        """Initialize tracker for one touch controller."""
+        self._instance = instance
+        self._start_byte = start_byte
+        self._last_by_address: dict[str, TouchEventData] = {}
+
+    def reset(self, address: str | None = None) -> None:
+        """Reset tracker state for one device or all devices."""
+        if address is None:
+            self._last_by_address.clear()
+        else:
+            self._last_by_address.pop(address, None)
+
+    def update(
+        self,
+        address: str,
+        advertisement: AdvertisementData,
+        timestamp: float | None = None,
+    ) -> list[TouchChangeEvent]:
+        """Process one advertisement and return detected touch transitions."""
+        current = advertisement.touch_event(self._start_byte)
+        if current is None:
+            return []
+
+        previous = self._last_by_address.get(address)
+        self._last_by_address[address] = current
+
+        if previous is None:
+            return []
+
+        if not previous.is_touching and not current.is_touching:
+            return []
+
+        now = timestamp if timestamp is not None else time.time()
+
+        if not previous.is_touching and current.is_touching:
+            event_type = "touch_down"
+        elif previous.is_touching and not current.is_touching:
+            event_type = "touch_up"
+        elif previous.x != current.x or previous.y != current.y:
+            event_type = "touch_move"
+        else:
+            return []
+
+        return [
+            TouchChangeEvent(
+                address=address,
+                instance=self._instance,
+                event_type=event_type,
+                x=current.x,
+                y=current.y,
+                contact_count=current.contact_count,
+                track_id=current.track_id,
+                timestamp=now,
+            )
+        ]
 
 
 LEGACY_LENGTH = 11

--- a/tests/unit/test_models_advertisement.py
+++ b/tests/unit/test_models_advertisement.py
@@ -410,6 +410,18 @@ class TestTouchTracker:
         events = tracker.update(self.ADDRESS, self._adv(1, x=10, y=10), timestamp=2.0)
         assert events == []
 
+    def test_reset_all_clears_every_address(self) -> None:
+        """reset() with no argument clears state for all tracked addresses."""
+        other = "11:22:33:44:55:66"
+        tracker = TouchTracker(instance=0, start_byte=0)
+        tracker.update(self.ADDRESS, self._adv(0), timestamp=1.0)
+        tracker.update(other, self._adv(0), timestamp=1.0)
+        tracker.reset()
+
+        # Both addresses should be treated as first advertisement → no events
+        assert tracker.update(self.ADDRESS, self._adv(1, x=5, y=5), timestamp=2.0) == []
+        assert tracker.update(other, self._adv(1, x=5, y=5), timestamp=2.0) == []
+
     def test_legacy_advertisement_returns_no_events(self) -> None:
         """Legacy advertisements (no dynamic_data) produce no touch events."""
         tracker = TouchTracker(instance=0, start_byte=0)

--- a/tests/unit/test_models_advertisement.py
+++ b/tests/unit/test_models_advertisement.py
@@ -5,6 +5,7 @@ import pytest
 from opendisplay.models.advertisement import (
     AdvertisementData,
     AdvertisementTracker,
+    TouchTracker,
     decode_button_event,
     parse_advertisement,
 )
@@ -223,3 +224,195 @@ class TestParseAdvertisement:
         assert [e.event_type for e in third_events] == ["button_up"]
         assert third_events[0].button_id == 2
         assert third_events[0].pressed is False
+
+
+class TestTouchEventData:
+    """Test TouchEventData parsing from dynamic data bytes."""
+
+    def _adv_with_touch(
+        self, contact_count: int, track_id: int, x: int, y: int, start_byte: int = 0
+    ) -> AdvertisementData:
+        """Build a v1 advertisement with touch data at the given offset."""
+        dynamic = bytearray(11)
+        dynamic[start_byte] = (contact_count & 0x0F) | ((track_id & 0x0F) << 4)
+        dynamic[start_byte + 1] = x & 0xFF
+        dynamic[start_byte + 2] = (x >> 8) & 0xFF
+        dynamic[start_byte + 3] = y & 0xFF
+        dynamic[start_byte + 4] = (y >> 8) & 0xFF
+        payload = _v1_payload(bytes(dynamic))
+        return parse_advertisement(payload)
+
+    def test_touch_event_idle(self) -> None:
+        """contact_count=0 → touch_idle, coordinates accessible."""
+        adv = self._adv_with_touch(contact_count=0, track_id=0, x=100, y=200)
+        event = adv.touch_event(0)
+        assert event is not None
+        assert event.contact_count == 0
+        assert event.event_type == "touch_idle"
+        assert not event.is_touching
+
+    def test_touch_event_active(self) -> None:
+        """contact_count=1 → touch_down with correct x/y/track_id."""
+        adv = self._adv_with_touch(contact_count=1, track_id=3, x=320, y=240)
+        event = adv.touch_event(0)
+        assert event is not None
+        assert event.contact_count == 1
+        assert event.track_id == 3
+        assert event.x == 320
+        assert event.y == 240
+        assert event.event_type == "touch_down"
+        assert event.is_touching
+
+    def test_touch_event_released(self) -> None:
+        """contact_count=6 → touch_up (released), coordinates latched."""
+        adv = self._adv_with_touch(contact_count=6, track_id=1, x=50, y=75)
+        event = adv.touch_event(0)
+        assert event is not None
+        assert event.contact_count == 6
+        assert event.event_type == "touch_up"
+        assert not event.is_touching
+        assert event.x == 50
+        assert event.y == 75
+
+    def test_touch_event_non_zero_start_byte(self) -> None:
+        """Touch data at start_byte=3 is parsed from the correct offset."""
+        adv = self._adv_with_touch(contact_count=2, track_id=0, x=128, y=64, start_byte=3)
+        event = adv.touch_event(3)
+        assert event is not None
+        assert event.contact_count == 2
+        assert event.x == 128
+        assert event.y == 64
+
+    def test_touch_event_returns_none_for_legacy(self) -> None:
+        """Legacy advertisements return None for touch_event()."""
+        data = bytes([0x02, 0x36, 0x00, 0x6C, 0x00, 0xC3, 0x01, 0x55, 0x0F, 0x16, 0x4D])
+        adv = parse_advertisement(data)
+        assert adv.touch_event(0) is None
+
+    def test_touch_event_out_of_range_returns_none(self) -> None:
+        """start_byte too large to fit 5-byte block returns None."""
+        payload = _v1_payload(bytes(11))
+        adv = parse_advertisement(payload)
+        assert adv.touch_event(7) is None  # 7+5=12 > 11
+
+    def test_touch_event_max_contacts(self) -> None:
+        """contact_count=5 (max) is still touch_down."""
+        adv = self._adv_with_touch(contact_count=5, track_id=0, x=10, y=10)
+        event = adv.touch_event(0)
+        assert event is not None
+        assert event.event_type == "touch_down"
+        assert event.is_touching
+
+
+class TestTouchTracker:
+    """Test TouchTracker state machine transitions."""
+
+    ADDRESS = "AA:BB:CC:DD:EE:FF"
+
+    def _adv(self, contact_count: int, x: int = 0, y: int = 0) -> AdvertisementData:
+        """Build v1 advertisement with touch data at start_byte=0."""
+        dynamic = bytearray(11)
+        dynamic[0] = contact_count & 0x0F
+        dynamic[1] = x & 0xFF
+        dynamic[2] = (x >> 8) & 0xFF
+        dynamic[3] = y & 0xFF
+        dynamic[4] = (y >> 8) & 0xFF
+        return parse_advertisement(_v1_payload(bytes(dynamic)))
+
+    def test_first_advertisement_emits_no_events(self) -> None:
+        """First update seeds state; no events emitted."""
+        tracker = TouchTracker(instance=0, start_byte=0)
+        adv = self._adv(contact_count=0)
+        assert tracker.update(self.ADDRESS, adv, timestamp=1.0) == []
+
+    def test_touch_down_on_idle_to_active(self) -> None:
+        """Transition from idle (0) to active (1) emits touch_down."""
+        tracker = TouchTracker(instance=0, start_byte=0)
+        tracker.update(self.ADDRESS, self._adv(0), timestamp=1.0)
+
+        events = tracker.update(self.ADDRESS, self._adv(1, x=100, y=200), timestamp=2.0)
+        assert len(events) == 1
+        assert events[0].event_type == "touch_down"
+        assert events[0].x == 100
+        assert events[0].y == 200
+        assert events[0].instance == 0
+        assert events[0].address == self.ADDRESS
+        assert events[0].timestamp == 2.0
+
+    def test_touch_up_on_active_to_released(self) -> None:
+        """Transition from active to released (6) emits touch_up."""
+        tracker = TouchTracker(instance=0, start_byte=0)
+        tracker.update(self.ADDRESS, self._adv(0), timestamp=1.0)
+        tracker.update(self.ADDRESS, self._adv(1, x=50, y=50), timestamp=2.0)
+
+        events = tracker.update(self.ADDRESS, self._adv(6, x=50, y=50), timestamp=3.0)
+        assert len(events) == 1
+        assert events[0].event_type == "touch_up"
+
+    def test_touch_up_on_active_to_idle(self) -> None:
+        """Transition directly from active to idle also emits touch_up."""
+        tracker = TouchTracker(instance=0, start_byte=0)
+        tracker.update(self.ADDRESS, self._adv(0), timestamp=1.0)
+        tracker.update(self.ADDRESS, self._adv(1, x=10, y=20), timestamp=2.0)
+
+        events = tracker.update(self.ADDRESS, self._adv(0), timestamp=3.0)
+        assert len(events) == 1
+        assert events[0].event_type == "touch_up"
+
+    def test_touch_move_on_position_change(self) -> None:
+        """Active→active with different coordinates emits touch_move."""
+        tracker = TouchTracker(instance=0, start_byte=0)
+        tracker.update(self.ADDRESS, self._adv(0), timestamp=1.0)
+        tracker.update(self.ADDRESS, self._adv(1, x=100, y=100), timestamp=2.0)
+
+        events = tracker.update(self.ADDRESS, self._adv(1, x=150, y=120), timestamp=3.0)
+        assert len(events) == 1
+        assert events[0].event_type == "touch_move"
+        assert events[0].x == 150
+        assert events[0].y == 120
+
+    def test_no_event_on_same_position(self) -> None:
+        """Active→active with same coordinates emits no event."""
+        tracker = TouchTracker(instance=0, start_byte=0)
+        tracker.update(self.ADDRESS, self._adv(0), timestamp=1.0)
+        tracker.update(self.ADDRESS, self._adv(1, x=100, y=100), timestamp=2.0)
+
+        events = tracker.update(self.ADDRESS, self._adv(1, x=100, y=100), timestamp=3.0)
+        assert events == []
+
+    def test_no_event_on_idle_to_idle(self) -> None:
+        """Idle→idle emits no event."""
+        tracker = TouchTracker(instance=0, start_byte=0)
+        tracker.update(self.ADDRESS, self._adv(0), timestamp=1.0)
+        events = tracker.update(self.ADDRESS, self._adv(0), timestamp=2.0)
+        assert events == []
+
+    def test_instance_number_in_event(self) -> None:
+        """TouchChangeEvent carries the correct instance number."""
+        tracker = TouchTracker(instance=2, start_byte=3)
+        dynamic = bytearray(11)
+        dynamic[3] = 1  # contact_count=1 at start_byte=3
+        adv_idle = parse_advertisement(_v1_payload(bytes(11)))
+        adv_touch = parse_advertisement(_v1_payload(bytes(dynamic)))
+
+        tracker.update(self.ADDRESS, adv_idle, timestamp=1.0)
+        events = tracker.update(self.ADDRESS, adv_touch, timestamp=2.0)
+        assert len(events) == 1
+        assert events[0].instance == 2
+
+    def test_reset_clears_state(self) -> None:
+        """After reset, first update for that address seeds state again."""
+        tracker = TouchTracker(instance=0, start_byte=0)
+        tracker.update(self.ADDRESS, self._adv(0), timestamp=1.0)
+        tracker.reset(self.ADDRESS)
+
+        # After reset, this should be treated as the first advertisement → no event
+        events = tracker.update(self.ADDRESS, self._adv(1, x=10, y=10), timestamp=2.0)
+        assert events == []
+
+    def test_legacy_advertisement_returns_no_events(self) -> None:
+        """Legacy advertisements (no dynamic_data) produce no touch events."""
+        tracker = TouchTracker(instance=0, start_byte=0)
+        legacy = bytes([0x02, 0x36, 0x00, 0x6C, 0x00, 0xC3, 0x01, 0x55, 0x0F, 0x16, 0x4D])
+        adv = parse_advertisement(legacy)
+        assert tracker.update(self.ADDRESS, adv, timestamp=1.0) == []

--- a/uv.lock
+++ b/uv.lock
@@ -861,7 +861,7 @@ wheels = [
 
 [[package]]
 name = "py-opendisplay"
-version = "7.0.0"
+version = "7.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "bleak" },


### PR DESCRIPTION
Parses 5-byte GT911 touch blocks from the v1 BLE advertisement dynamic data, emitting touch_down / touch_move / touch_up events via TouchTracker. Mirrors the existing AdvertisementTracker pattern for buttons.