### PR TITLE
improve CI workflows

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,15 +6,20 @@ on:
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  group: lint-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v8.1.0
 
       - name: Set up Python
         run: uv python install 3.11

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,56 +11,57 @@ on:
         required: false
         type: string
 
-permissions:
-  contents: write
-  pull-requests: write
-  id-token: write  # For PyPI trusted publishing
+permissions: {}
+
+concurrency:
+  group: release
+  cancel-in-progress: false
 
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+      pull-requests: write
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@v5
         id: release
         with:
-          release-type: python
-          package-name: py-opendisplay
-          bump-minor-pre-major: true
-          bump-patch-for-minor-pre-major: true
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json
 
-      # The following steps only run if a release was created, or a tag was provided manually
-      - name: Checkout code
-        if: ${{ steps.release.outputs.release_created || inputs.tag }}
-        uses: actions/checkout@v4
+  publish:
+    needs: release-please
+    if: needs.release-please.outputs.release_created == 'true' || inputs.tag != ''
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
         with:
-          ref: ${{ inputs.tag || '' }}
+          ref: ${{ inputs.tag || needs.release-please.outputs.tag_name }}
 
       - name: Set up Python
-        if: ${{ steps.release.outputs.release_created || inputs.tag }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
       - name: Install uv
-        if: ${{ steps.release.outputs.release_created || inputs.tag }}
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v8.1.0
 
       - name: Install dependencies
-        if: ${{ steps.release.outputs.release_created || inputs.tag }}
         run: uv sync
 
-      # - name: Run tests
-      #   if: ${{ steps.release.outputs.release_created || inputs.tag }}
-      #   run: uv run pytest tests/ -v
-
-      # - name: Run linter
-      #   if: ${{ steps.release.outputs.release_created || inputs.tag }}
-      #   run: uv run ruff check .
-
       - name: Build package
-        if: ${{ steps.release.outputs.release_created || inputs.tag }}
         run: uv build
 
       - name: Publish to PyPI
-        if: ${{ steps.release.outputs.release_created || inputs.tag }}
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          verbose: true
+          skip-existing: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v8.1.0
+        with:
+          cache-suffix: ${{ matrix.python-version }}
 
       - name: Set up Python ${{ matrix.python-version }}
         run: uv python install ${{ matrix.python-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,19 +6,26 @@ on:
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  group: test-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: Test Suite (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
+    timeout-minutes: 20
+    continue-on-error: ${{ matrix.python-version == '3.14' }}
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.11", "3.12", "3.13", "3.14"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v8.1.0
 
       - name: Set up Python ${{ matrix.python-version }}
         run: uv python install ${{ matrix.python-version }}
@@ -35,7 +42,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: matrix.python-version == '3.11'
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v6
         with:
-          file: ./coverage.xml
+          files: ./coverage.xml
           fail_ci_if_error: false


### PR DESCRIPTION
- Split release-please and publish into separate jobs so publish can be retried independently without the workflow_dispatch tag hack
- Scope id-token:write to publish job only; release-please job no longer gets the OIDC token
- Remove deprecated release-please-action inputs (already in config file)
- Add skip-existing and verbose to PyPI publish for resilience
- Bump all actions to Node 24 versions (Node 20 removed June 2026): release-please-action v4→v5, checkout v4→v6, setup-python v5→v6, setup-uv v3/v4→v8.1.0 (exact pin required by v8), codecov v4→v6
- Fix codecov file: → files: (deprecated param rename)
- Add concurrency controls to cancel superseded runs on PRs
- Add timeout-minutes to all jobs
- Add fail-fast: false and continue-on-error for Python 3.14 pre-release