### PR TITLE
Encode GRAYSCALE_4 as two 1-bit planes host-side

### DIFF
--- a/src/opendisplay/device.py
+++ b/src/opendisplay/device.py
@@ -20,10 +20,11 @@ from .crypto import (
     encrypt_command,
     generate_client_nonce,
 )
-from .display_palettes import PANELS_4GRAY, get_palette_for_display
+from .display_palettes import PANELS_4GRAY, get_gray4_codes, get_palette_for_display
 from .encoding import (
     compress_image_data,
     encode_bitplanes,
+    encode_gray4_bitplanes,
     encode_image,
     fit_image,
 )
@@ -236,6 +237,10 @@ def prepare_image(
     if color_scheme in (ColorScheme.BWR, ColorScheme.BWY):
         plane1, plane2 = encode_bitplanes(dithered, color_scheme)
         image_data = plane1 + plane2
+    elif color_scheme == ColorScheme.GRAYSCALE_4:
+        # Two pre-split 1-bit planes; firmware streams them to PLANE_0/PLANE_1.
+        plane0, plane1 = encode_gray4_bitplanes(dithered, get_gray4_codes(panel_ic_type))
+        image_data = plane0 + plane1
     else:
         image_data = encode_image(dithered, color_scheme)
 
@@ -1133,6 +1138,14 @@ class OpenDisplayDevice:
                 new_etag=new_etag,
             )
         else:
+            if self.color_scheme == ColorScheme.GRAYSCALE_4:
+                # 4-gray ships two split planes that only the firmware's compressed
+                # path accepts; an uncompressed upload is rejected outright (and the
+                # split-plane shape is incompatible with older packed-2bpp firmware).
+                raise ProtocolError(
+                    "GRAYSCALE_4 uploads must be compressed; enable ZIP transport and "
+                    "ensure the compressed image fits the device buffer"
+                )
             if compress and not supports_compression:
                 _LOGGER.info("Device does not support compressed uploads, using uncompressed protocol")
             elif compress and compressed_data:
@@ -1354,7 +1367,9 @@ class OpenDisplayDevice:
         try:
             validate_ack_response(response, CommandCode.DIRECT_WRITE_START)
         except InvalidResponseError:
-            if not use_compression:
+            # 4-gray has no uncompressed protocol to fall back to (firmware rejects it),
+            # so surface the compressed START failure directly instead of retrying.
+            if not use_compression or self.color_scheme == ColorScheme.GRAYSCALE_4:
                 raise
             # Device rejected the compressed START (e.g., compressedDataBuffer is NULL —
             # ZIPXL bit set in config but firmware not built with PSRAM support).

--- a/src/opendisplay/device.py
+++ b/src/opendisplay/device.py
@@ -238,9 +238,8 @@ def prepare_image(
         plane1, plane2 = encode_bitplanes(dithered, color_scheme)
         image_data = plane1 + plane2
     elif color_scheme == ColorScheme.GRAYSCALE_4:
-        # Two pre-split 1-bit planes; firmware streams them to PLANE_0/PLANE_1.
-        plane0, plane1 = encode_gray4_bitplanes(dithered, get_gray4_codes(panel_ic_type))
-        image_data = plane0 + plane1
+        # Two pre-split 1-bit planes concatenated; firmware streams the halves to PLANE_0/PLANE_1.
+        image_data = b"".join(encode_gray4_bitplanes(dithered, get_gray4_codes(panel_ic_type)))
     else:
         image_data = encode_image(dithered, color_scheme)
 

--- a/src/opendisplay/display_palettes.py
+++ b/src/opendisplay/display_palettes.py
@@ -14,6 +14,7 @@ PANELS_4GRAY: frozenset[int] = frozenset(
     {
         0x0008,  # EP295_128x296_4GRAY
         0x0015,  # EP75_800x480_4GRAY
+        0x0016,  # EP75_800x480_4GRAY_V2
         0x0018,  # EP29_128x296_4GRAY
         0x0028,  # EP426_800x480_4GRAY
         0x002F,  # EP29Z_128x296_4GRAY
@@ -21,6 +22,24 @@ PANELS_4GRAY: frozenset[int] = frozenset(
         0x003C,  # EP75_800x480_4GRAY_GEN2
     }
 )
+
+# Per-panel 4-gray code tables, mirroring bb_epaper's pColorLookup (bb_ep.inl).
+# Maps dither level (0=black .. 3=white) -> the 2-bit code stored in the panel's
+# two controller planes; plane0 = code bit0, plane1 = code bit1 (bbepSetPixel4Gray).
+# Both endpoints map black->3 and white->0; only EP426 swaps the mid-grays (v2).
+_GRAY4_CODES_BASE: tuple[int, int, int, int] = (3, 1, 2, 0)  # u8Colors_4gray
+_GRAY4_CODES_V2: tuple[int, int, int, int] = (3, 2, 1, 0)  # u8Colors_4gray_v2
+_GRAY4_CODES_BY_PANEL: dict[int, tuple[int, int, int, int]] = {
+    0x0028: _GRAY4_CODES_V2,  # EP426_800x480_4GRAY
+}
+
+
+def get_gray4_codes(panel_ic_type: int | None) -> tuple[int, int, int, int]:
+    """Return the 4-gray level->stored-code table for a panel (bb_epaper parity)."""
+    if panel_ic_type is None:
+        return _GRAY4_CODES_BASE
+    return _GRAY4_CODES_BY_PANEL.get(panel_ic_type, _GRAY4_CODES_BASE)
+
 
 # Map: (panel_ic_type, color_scheme) -> measured ColorPalette
 # panel_ic_type identifies the e-paper panel model

--- a/src/opendisplay/encoding/__init__.py
+++ b/src/opendisplay/encoding/__init__.py
@@ -1,6 +1,6 @@
 """Image encoding and processing."""
 
-from .bitplanes import encode_bitplanes
+from .bitplanes import encode_bitplanes, encode_gray4_bitplanes
 from .compression import compress_image_data, decompress_image_data
 from .images import encode_1bpp, encode_2bpp, encode_4bpp, encode_image, fit_image
 
@@ -11,6 +11,7 @@ __all__ = [
     "encode_2bpp",
     "encode_4bpp",
     "encode_bitplanes",
+    "encode_gray4_bitplanes",
     "compress_image_data",
     "decompress_image_data",
 ]

--- a/src/opendisplay/encoding/bitplanes.py
+++ b/src/opendisplay/encoding/bitplanes.py
@@ -66,3 +66,47 @@ def encode_bitplanes(
             # else: palette_idx == 0 (black) - both planes stay 0
 
     return bytes(plane1), bytes(plane2)
+
+
+def encode_gray4_bitplanes(
+    image: Image.Image,
+    gray_codes: tuple[int, int, int, int],
+) -> tuple[bytes, bytes]:
+    """Encode a 4-gray palette image to two 1-bit controller planes.
+
+    Each pixel's dither level (palette index 0=black..3=white) is mapped through
+    the panel's gray-code table to a 2-bit stored code; plane0 carries the code's
+    bit0 and plane1 its bit1, matching the firmware's bbepSetPixel4Gray. The
+    firmware streams these planes straight to PLANE_0/PLANE_1, so no on-device
+    de-interleave is needed.
+
+    Args:
+        image: Dithered palette image (mode "P", indices 0..3)
+        gray_codes: level -> stored 2-bit code (see display_palettes.get_gray4_codes)
+
+    Returns:
+        Tuple of (plane0_bytes, plane1_bytes)
+
+    Raises:
+        ValueError: If image is not a palette image
+    """
+    if image.mode != "P":
+        raise ValueError(f"Expected palette image, got {image.mode}")
+
+    pixels = np.array(image)
+    height, width = pixels.shape
+    bytes_per_row = (width + 7) // 8
+    plane0 = bytearray(bytes_per_row * height)
+    plane1 = bytearray(bytes_per_row * height)
+
+    for y in range(height):
+        for x in range(width):
+            byte_idx = y * bytes_per_row + x // 8
+            bit = 1 << (7 - (x % 8))  # MSB first
+            code = gray_codes[int(pixels[y, x]) & 0x03]
+            if code & 0x01:
+                plane0[byte_idx] |= bit
+            if code & 0x02:
+                plane1[byte_idx] |= bit
+
+    return bytes(plane0), bytes(plane1)

--- a/src/opendisplay/partial.py
+++ b/src/opendisplay/partial.py
@@ -85,7 +85,9 @@ def compute_partial_region(
     if not display.partial_update_support:
         return "fallback_full"
 
-    if color_scheme in (ColorScheme.BWR, ColorScheme.BWY):
+    # Firmware only supports partial refresh on 1bpp panels; 4-gray (and the
+    # 3-color schemes) are rejected, so don't attempt a doomed partial round-trip.
+    if color_scheme in (ColorScheme.BWR, ColorScheme.BWY, ColorScheme.GRAYSCALE_4):
         return "fallback_full"
 
     width, height = processed_image.size

--- a/tests/unit/test_device_upload_flow.py
+++ b/tests/unit/test_device_upload_flow.py
@@ -17,7 +17,11 @@ import pytest
 from epaper_dithering import ColorScheme
 
 from opendisplay import OpenDisplayDevice
-from opendisplay.exceptions import AuthenticationRequiredError
+from opendisplay.exceptions import (
+    AuthenticationRequiredError,
+    InvalidResponseError,
+    ProtocolError,
+)
 from opendisplay.models.capabilities import DeviceCapabilities
 from opendisplay.models.config import (
     DisplayConfig,
@@ -452,3 +456,42 @@ def test_prepare_image_defaults_tone_and_gamut_off() -> None:
     sig = inspect.signature(_Dev._prepare_image)
     assert sig.parameters["tone"].default == 0.0
     assert sig.parameters["gamut"].default == 0.0
+
+
+# ─── GRAYSCALE_4: compressed-only enforcement ────────────────────────────────
+
+
+def _make_gray4_device(transmission_modes: int = 0x02) -> OpenDisplayDevice:
+    """Device reporting a 4-gray panel (uploads must be compressed split planes)."""
+    config = _make_config(transmission_modes=transmission_modes, width=8, height=8)
+    caps = DeviceCapabilities(width=8, height=8, color_scheme=ColorScheme.GRAYSCALE_4)
+    return OpenDisplayDevice(mac_address="AA:BB:CC:DD:EE:FF", config=config, capabilities=caps)
+
+
+@pytest.mark.asyncio
+async def test_gray4_uncompressed_dispatch_raises_before_start() -> None:
+    """4-gray has no uncompressed protocol; _dispatch_upload raises before any 0x70."""
+    device = _make_gray4_device()
+    fake = _FakeConnection([])
+    device._connection = fake
+    with pytest.raises(ProtocolError, match="must be compressed"):
+        # compress=False forces the uncompressed branch, which is invalid for 4-gray
+        await device._dispatch_upload(b"\x00" * 16, RefreshMode.FULL, False, None, None)
+    assert fake.written == []  # nothing sent to the device
+
+
+@pytest.mark.asyncio
+async def test_gray4_compressed_start_rejected_does_not_fall_back() -> None:
+    """A rejected compressed START for 4-gray surfaces directly (no uncompressed retry)."""
+    device = _make_gray4_device()
+    fake = _FakeConnection([ERR_FRAME])  # reject compressed START, offer no retry response
+    device._connection = fake
+    with pytest.raises(InvalidResponseError):
+        await device._execute_upload(
+            b"\x00" * 16,
+            RefreshMode.FULL,
+            use_compression=True,
+            compressed_data=b"\xff" * 5,
+            uncompressed_size=16,
+        )
+    assert len(fake.written) == 1  # only the compressed START; no bare-START retry

--- a/tests/unit/test_encoding_gray4.py
+++ b/tests/unit/test_encoding_gray4.py
@@ -1,0 +1,98 @@
+"""Tests for 4-gray bitplane encoding (host-side de-interleave for GRAYSCALE_4)."""
+
+import numpy as np
+from PIL import Image
+
+from opendisplay.display_palettes import get_gray4_codes
+from opendisplay.encoding.bitplanes import encode_gray4_bitplanes
+from opendisplay.encoding.images import encode_2bpp
+
+EP426_PANEL_IC = 0x0028  # uses the v2 gray-code table
+BASE_PANEL_IC = 0x0008  # EP295: uses the base gray-code table
+
+
+def _img(levels: np.ndarray) -> Image.Image:
+    return Image.fromarray(levels.astype(np.uint8), mode="P")
+
+
+def _deinterleave_like_firmware(image: Image.Image, codes: tuple[int, int, int, int]) -> tuple[bytes, bytes]:
+    """Reference: how the original (validated) firmware split encode_2bpp output.
+
+    For each pixel it read the 2-bit level, mapped it through the panel's gray
+    LUT, then wrote stored-code bit0 -> plane0 and bit1 -> plane1 (PLANE_0/PLANE_1
+    in bbepSetPixel4Gray order). Widths here are multiples of 8 so the 2bpp and
+    1bpp row paddings line up.
+    """
+    packed = encode_2bpp(image)
+    width, height = image.size
+    bpr2 = (width + 3) // 4
+    bpr1 = (width + 7) // 8
+    plane0 = bytearray(bpr1 * height)
+    plane1 = bytearray(bpr1 * height)
+    for y in range(height):
+        for x in range(width):
+            level = (packed[y * bpr2 + x // 4] >> ((3 - (x % 4)) * 2)) & 0x03
+            stored = codes[level]
+            mask = 0x80 >> (x % 8)
+            if stored & 0x01:
+                plane0[y * bpr1 + x // 8] |= mask
+            if stored & 0x02:
+                plane1[y * bpr1 + x // 8] |= mask
+    return bytes(plane0), bytes(plane1)
+
+
+def test_matches_firmware_deinterleave_v2():
+    """New host planes are bit-identical to the firmware's de-interleave (EP426/v2)."""
+    rng = np.random.default_rng(1)
+    levels = rng.integers(0, 4, size=(7, 800), dtype=np.uint8)  # all 4 levels, 800 wide
+    img = _img(levels)
+    codes = get_gray4_codes(EP426_PANEL_IC)
+
+    p0, p1 = encode_gray4_bitplanes(img, codes)
+    e0, e1 = _deinterleave_like_firmware(img, codes)
+    assert p0 == e0
+    assert p1 == e1
+
+
+def test_matches_firmware_deinterleave_base():
+    """Same equivalence holds for the base gray-code table (non-EP426 panels)."""
+    rng = np.random.default_rng(2)
+    levels = rng.integers(0, 4, size=(5, 16), dtype=np.uint8)
+    img = _img(levels)
+    codes = get_gray4_codes(BASE_PANEL_IC)
+
+    p0, p1 = encode_gray4_bitplanes(img, codes)
+    e0, e1 = _deinterleave_like_firmware(img, codes)
+    assert p0 == e0
+    assert p1 == e1
+
+
+def test_endpoints_black_and_white():
+    """Black (level 0) and white (level 3) are table-independent: black->code 3, white->code 0."""
+    for panel in (EP426_PANEL_IC, BASE_PANEL_IC):
+        codes = get_gray4_codes(panel)
+        assert codes[0] == 0b11  # black -> both plane bits set
+        assert codes[3] == 0b00  # white -> both plane bits clear
+
+    black = _img(np.zeros((1, 8), dtype=np.uint8))
+    p0, p1 = encode_gray4_bitplanes(black, get_gray4_codes(EP426_PANEL_IC))
+    assert p0[0] == 0xFF and p1[0] == 0xFF
+
+    white = _img(np.full((1, 8), 3, dtype=np.uint8))
+    p0, p1 = encode_gray4_bitplanes(white, get_gray4_codes(EP426_PANEL_IC))
+    assert p0[0] == 0x00 and p1[0] == 0x00
+
+
+def test_plane_lengths():
+    """Each plane is one 1bpp frame (row-padded to 8px)."""
+    img = _img(np.zeros((10, 12), dtype=np.uint8))
+    p0, p1 = encode_gray4_bitplanes(img, get_gray4_codes(EP426_PANEL_IC))
+    assert len(p0) == len(p1) == ((12 + 7) // 8) * 10
+
+
+def test_v2_and_base_differ_on_midgrays():
+    """The two tables agree on black/white but swap the mid-grays."""
+    v2 = get_gray4_codes(EP426_PANEL_IC)
+    base = get_gray4_codes(BASE_PANEL_IC)
+    assert v2[0] == base[0] and v2[3] == base[3]
+    assert v2[1] != base[1] and v2[2] != base[2]

--- a/tests/unit/test_encoding_gray4.py
+++ b/tests/unit/test_encoding_gray4.py
@@ -1,11 +1,15 @@
 """Tests for 4-gray bitplane encoding (host-side de-interleave for GRAYSCALE_4)."""
 
 import numpy as np
+import pytest
+from epaper_dithering import ColorScheme
 from PIL import Image
 
-from opendisplay.display_palettes import get_gray4_codes
+from opendisplay import prepare_image
+from opendisplay.display_palettes import _GRAY4_CODES_BASE, get_gray4_codes
 from opendisplay.encoding.bitplanes import encode_gray4_bitplanes
 from opendisplay.encoding.images import encode_2bpp
+from opendisplay.models.capabilities import DeviceCapabilities
 
 EP426_PANEL_IC = 0x0028  # uses the v2 gray-code table
 BASE_PANEL_IC = 0x0008  # EP295: uses the base gray-code table
@@ -96,3 +100,26 @@ def test_v2_and_base_differ_on_midgrays():
     base = get_gray4_codes(BASE_PANEL_IC)
     assert v2[0] == base[0] and v2[3] == base[3]
     assert v2[1] != base[1] and v2[2] != base[2]
+
+
+def test_get_gray4_codes_none_defaults_to_base():
+    """An unknown panel (None) falls back to the base table, not a crash."""
+    assert get_gray4_codes(None) == _GRAY4_CODES_BASE
+
+
+def test_encode_gray4_rejects_non_palette_image():
+    """Only palette ('P') images carry dither levels; anything else is a caller error."""
+    with pytest.raises(ValueError, match="palette image"):
+        encode_gray4_bitplanes(Image.new("L", (8, 1)), get_gray4_codes(EP426_PANEL_IC))
+
+
+def test_prepare_image_gray4_concatenates_planes():
+    """prepare_image routes GRAYSCALE_4 through the two-plane encoder and concatenates plane0+plane1."""
+    levels = np.tile(np.array([0, 64, 128, 192, 255, 128, 64, 0], dtype=np.uint8), (2, 1))
+    src = Image.fromarray(levels, mode="L")
+    caps = DeviceCapabilities(width=8, height=2, color_scheme=ColorScheme.GRAYSCALE_4)
+
+    data, _, dithered = prepare_image(src, capabilities=caps, panel_ic_type=EP426_PANEL_IC, compress=False)
+
+    p0, p1 = encode_gray4_bitplanes(dithered, get_gray4_codes(EP426_PANEL_IC))
+    assert data == p0 + p1


### PR DESCRIPTION
As per the feedback on https://github.com/OpenDisplay/Firmware/pull/33, I reverted the upload code in that PR (kept the boot stuff) and added it here. Did a bunch of manual testing, seems to be good. But as before: please let me know if I'm not properly matching your preferred code conventions, commenting-style, etc. Happy to iterate.

Commit message:

4-gray images now de-interleave into two pre-split 1-bit controller planes (plane0 ++ plane1) on the host, mirroring the existing BWR/BWY bitplane path, instead of shipping packed 2bpp for the firmware to split. The panel's gray-code table (bb_epaper pColorLookup parity) is applied here via get_gray4_codes, so the firmware just streams each plane to PLANE_0/PLANE_1 — no on-device de-interleave or 2bpp frame buffer.

The split-plane stream is compressed-only: firmware rejects uncompressed 4-gray and older firmware expects packed 2bpp, so _dispatch_upload raises rather than falling back to uncompressed, and a rejected compressed START is surfaced instead of retried uncompressed.

Also: skip partial updates for 4-gray (firmware only supports 1bpp partial), and add panel 0x0016 (EP75_800x480_4GRAY_V2) to PANELS_4GRAY so it is not flagged as an unknown 4-gray panel.

Tests prove the planes are bit-identical to the prior firmware de-interleave of encode_2bpp (base and EP426/v2 tables) and cover the compressed-only enforcement.