### PR TITLE
Fix serialize_display_config dropping full_update_mC

### DIFF
--- a/src/opendisplay/models/config.py
+++ b/src/opendisplay/models/config.py
@@ -237,7 +237,7 @@ class PowerOption:
 class DisplayConfig:
     """Display configuration (TLV packet type 0x20, repeatable max 4).
 
-    Size: 66 bytes (packed struct from firmware)
+    Size: 46 bytes (packed struct from firmware)
     """
 
     instance_number: int  # uint8 (0-3)

--- a/src/opendisplay/protocol/config_serializer.py
+++ b/src/opendisplay/protocol/config_serializer.py
@@ -204,7 +204,8 @@ def serialize_display_config(config: DisplayConfig) -> bytes:
     - transmission_modes: uint8
     - clk_pin: uint8
     - reserved_pins: 7 bytes
-    - reserved: 15 bytes
+    - full_update_mC: uint16
+    - reserved: 13 bytes
 
     Args:
         config: DisplayConfig instance
@@ -238,9 +239,13 @@ def serialize_display_config(config: DisplayConfig) -> bytes:
     reserved_pins = config.reserved_pins if config.reserved_pins else b"\xff" * 7
     data += reserved_pins[:7]
 
-    # Add reserved bytes (15 bytes) to total 46
-    reserved = config.reserved if config.reserved else b"\x00" * 15
-    return data + reserved[:15]
+    # full_update_mC (uint16 LE) sits between reserved_pins and reserved in the
+    # firmware struct; omitting it truncates the packet and the device drops the display.
+    data += struct.pack("<H", config.full_update_mC)
+
+    # Add reserved bytes (13) to total 46
+    reserved = config.reserved if config.reserved else b"\x00" * 13
+    return data + reserved[:13].ljust(13, b"\x00")
 
 
 def serialize_led_config(config: LedConfig) -> bytes:

--- a/tests/unit/test_required_packets.py
+++ b/tests/unit/test_required_packets.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import struct
+from dataclasses import replace
 
 import pytest
 
@@ -18,8 +19,12 @@ from opendisplay.models.config import (
     PowerOption,
     SystemConfig,
 )
-from opendisplay.protocol.config_parser import parse_tlv_config
-from opendisplay.protocol.config_serializer import serialize_binary_inputs
+from opendisplay.protocol.config_parser import parse_config_response, parse_tlv_config
+from opendisplay.protocol.config_serializer import (
+    serialize_binary_inputs,
+    serialize_config,
+    serialize_display_config,
+)
 
 
 def _system_payload() -> bytes:
@@ -354,3 +359,29 @@ async def test_write_config_still_requires_display() -> None:
 
     with pytest.raises(ValueError, match="at least one display"):
         await device.write_config(cfg)
+
+
+def test_serialize_display_config_matches_firmware_struct_size() -> None:
+    """Firmware's packed DisplayConfig is 46 bytes; a shorter packet makes the device drop the display."""
+    assert len(serialize_display_config(_minimal_display())) == 46
+
+
+def test_config_roundtrip_preserves_display_and_full_update_mc() -> None:
+    """serialize_config -> parse_config_response must preserve the display.
+
+    Regression: the serializer dropped full_update_mC, truncating the 0x20 packet
+    to 44 bytes so the firmware skipped it ("No display configured").
+    """
+    display = replace(_minimal_display(), full_update_mC=12345, color_scheme=5)
+    cfg = GlobalConfig(
+        system=_minimal_system(),
+        manufacturer=_minimal_manufacturer(),
+        power=_minimal_power(),
+        displays=[display],
+    )
+
+    parsed = parse_config_response(serialize_config(cfg))
+
+    assert len(parsed.displays) == 1
+    assert parsed.displays[0].full_update_mC == 12345
+    assert parsed.displays[0].color_scheme == 5


### PR DESCRIPTION
Ran into this while doing my local testing. Apparently most people do their config writes via the web (which works great). 😄

Commit message:

serialize_display_config omitted the uint16 full_update_mC field and padded reserved to 15 bytes, producing a 44-byte display packet. The parser and firmware expect 46 (reserved is 13 bytes after full_update_mC), so the device dropped the display ('No display configured') on every write_config. Emit full_update_mC and pad reserved to 13; add a packet-size and serialize->parse round-trip regression test.