### PR TITLE
feat: BLE OTA firmware updates over Bluetooth proxies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,8 @@ cli = [
 nrf-ota = [
     "nrf-ota>=0.3.0",
 ]
+# silabs-ota extra (silabs-ble-ota) is added once that package is published to
+# PyPI; until then the perform_silabs_ota wrapper imports it lazily.
 test = [
     "pytest>=9.0.2",
     "pytest-asyncio>=1.3.0",
@@ -78,7 +80,7 @@ warn_return_any = true
 warn_unused_configs = true
 
 [[tool.mypy.overrides]]
-module = ["nrf_ota.*"]
+module = ["nrf_ota.*", "silabs_ble_ota.*"]
 ignore_missing_imports = true
 
 [tool.pylint.format]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,8 +45,9 @@ cli = [
 nrf-ota = [
     "nrf-ota>=0.3.0",
 ]
-# silabs-ota extra (silabs-ble-ota) is added once that package is published to
-# PyPI; until then the perform_silabs_ota wrapper imports it lazily.
+silabs-ota = [
+    "silabs-ble-ota>=0.1.0",
+]
 test = [
     "pytest>=9.0.2",
     "pytest-asyncio>=1.3.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ cli = [
     "rich>=13.0.0",
 ]
 nrf-ota = [
-    "nrf-ota>=0.3.0",
+    "nrf-ota>=0.4.0",
 ]
 silabs-ota = [
     "silabs-ble-ota>=0.1.0",

--- a/src/opendisplay/device.py
+++ b/src/opendisplay/device.py
@@ -745,6 +745,28 @@ class OpenDisplayDevice:
             self.mac_address,
         )
 
+    async def clear_gatt_cache(self) -> bool:
+        """Clear the cached GATT table for this device on the active connection.
+
+        Use this on the Silabs (EFR32BG22) OTA path *before* calling
+        ``trigger_dfu_bootloader()``, while still connected in app mode: it
+        clears an ESPHome Bluetooth proxy's stale per-MAC GATT cache so that the
+        post-reboot connection to the AppLoader re-discovers the OTA service
+        instead of returning the cached app-firmware table. The device keeps the
+        same address across the reboot, so without this the proxy would serve
+        the wrong GATT and the OTA characteristics would not be found.
+
+        No-op (returns False) on backends without cache support (e.g. direct
+        BlueZ on a bleak build lacking ``clear_cache``).
+
+        Returns:
+            True if a cache was cleared, False if unsupported by the backend.
+
+        Raises:
+            BLEConnectionError: If the device is not connected.
+        """
+        return await self._conn.clear_cache()
+
     async def activate_led(
         self,
         led_instance: int,

--- a/src/opendisplay/device.py
+++ b/src/opendisplay/device.py
@@ -738,8 +738,24 @@ class OpenDisplayDevice:
         Raises:
             BLEConnectionError: If the command cannot be sent
         """
+        from .exceptions import BLEConnectionError
+
         _LOGGER.debug("Triggering DFU bootloader on device %s", self.mac_address)
-        await self._write(build_enter_dfu_command())
+        try:
+            await self._write(build_enter_dfu_command())
+        except BLEConnectionError as exc:
+            # The firmware resets before it can ACK this command — it has no time
+            # to send a write response — so the confirmation never arrives. With a
+            # write-with-response transport, especially over a Bluetooth proxy,
+            # that surfaces as a GATT/disconnect error (e.g. error 133) even though
+            # the command was delivered and the device is already entering DFU.
+            # Treat a write failure here as expected rather than fatal; whether the
+            # device actually entered DFU is determined by the subsequent scan for
+            # the DFU-mode device.
+            _LOGGER.debug(
+                "DFU trigger write did not ACK (expected — device resets before responding): %s",
+                exc,
+            )
         _LOGGER.info(
             "DFU bootloader trigger sent to %s — device will disconnect and enter DFU mode",
             self.mac_address,

--- a/src/opendisplay/ota.py
+++ b/src/opendisplay/ota.py
@@ -83,12 +83,13 @@ async def perform_nrf_dfu(
             log("Warning: could not read DFU version")
 
         # Over a Bluetooth proxy the DFU Packet characteristic (write-without-
-        # response) is silently dropped if bursted, so pace within each PRN batch.
-        # 0.02s is the proven-reliable value (full flash boots). 0.01s was tried
-        # and REGRESSED: it dropped a packet → the bootloader rejected the image
-        # and stayed in DFU. Legacy DFU can't retransmit, so keep the safe pace.
-        # A direct connection has real flow control, so fast mode sends unpaced.
-        inter_packet_delay = 0.0 if fast else 0.02
+        # response) is dropped if it overruns the proxy's buffer, and Legacy DFU
+        # can't retransmit, so a single drop fails the whole 11.7k-packet transfer.
+        # 0.01/0.02s both dropped intermittently; 0.05s gives the proxy far more
+        # drain time per packet (~8-10min) to test whether the drops are
+        # pacing-sensitive buffer overruns. A direct connection has real flow
+        # control, so fast mode sends unpaced.
+        inter_packet_delay = 0.0 if fast else 0.05
         await dfu.start()
         await dfu.start_dfu(len(zip_info.firmware), TYPE_APPLICATION)
         await dfu.init_dfu(zip_info.init_packet)

--- a/src/opendisplay/ota.py
+++ b/src/opendisplay/ota.py
@@ -84,10 +84,11 @@ async def perform_nrf_dfu(
 
         # Over a Bluetooth proxy the DFU Packet characteristic (write-without-
         # response) is silently dropped if bursted, so pace within each PRN batch.
-        # 0.02s reached 100% reliably; 0.01s (~2 packets per connection interval)
-        # is the tuned value — faster, with less headroom on a distant/busy proxy.
+        # 0.02s is the proven-reliable value (full flash boots). 0.01s was tried
+        # and REGRESSED: it dropped a packet → the bootloader rejected the image
+        # and stayed in DFU. Legacy DFU can't retransmit, so keep the safe pace.
         # A direct connection has real flow control, so fast mode sends unpaced.
-        inter_packet_delay = 0.0 if fast else 0.01
+        inter_packet_delay = 0.0 if fast else 0.02
         await dfu.start()
         await dfu.start_dfu(len(zip_info.firmware), TYPE_APPLICATION)
         await dfu.init_dfu(zip_info.init_packet)

--- a/src/opendisplay/ota.py
+++ b/src/opendisplay/ota.py
@@ -84,10 +84,10 @@ async def perform_nrf_dfu(
 
         # Over a Bluetooth proxy the DFU Packet characteristic (write-without-
         # response) is silently dropped if bursted, so pace within each PRN batch.
-        # 0.02s reached 100% through a real proxy at a reasonable speed; a smaller
-        # PRN proved far too slow (receipt round-trips dominate). A direct
-        # connection has real flow control, so fast mode sends unpaced.
-        inter_packet_delay = 0.0 if fast else 0.02
+        # 0.02s reached 100% reliably; 0.01s (~2 packets per connection interval)
+        # is the tuned value — faster, with less headroom on a distant/busy proxy.
+        # A direct connection has real flow control, so fast mode sends unpaced.
+        inter_packet_delay = 0.0 if fast else 0.01
         await dfu.start()
         await dfu.start_dfu(len(zip_info.firmware), TYPE_APPLICATION)
         await dfu.init_dfu(zip_info.init_packet)

--- a/src/opendisplay/ota.py
+++ b/src/opendisplay/ota.py
@@ -82,17 +82,23 @@ async def perform_nrf_dfu(
         except Exception:  # noqa: BLE001
             log("Warning: could not read DFU version")
 
-        # Pace packets within each PRN batch unless fast: the DFU Packet
-        # characteristic is write-without-response, which a Bluetooth proxy can
-        # silently drop when bursted (0.02s ≈ one packet per connection interval,
-        # the rate init_dfu already uses successfully through a proxy).
+        # Tune the firmware stream for a Bluetooth proxy unless fast. The DFU
+        # Packet characteristic is write-without-response, which a proxy silently
+        # drops when its buffer overruns — and HA may route through a distant/busy
+        # proxy with low throughput. Small PRN batches make the receipt round-trip
+        # pace the sender *adaptively* to the link (a slow proxy returns receipts
+        # slower, throttling us) and fully drain the proxy buffer between batches;
+        # the small inter-packet delay guards the within-batch burst. A direct
+        # connection has real flow control, so fast mode uses the larger default
+        # PRN and no delay.
         inter_packet_delay = 0.0 if fast else 0.02
+        prn = DEFAULT_PRN if fast else 4
         await dfu.start()
         await dfu.start_dfu(len(zip_info.firmware), TYPE_APPLICATION)
         await dfu.init_dfu(zip_info.init_packet)
         await dfu.send_firmware(
             zip_info.firmware,
-            packets_per_notification=DEFAULT_PRN,
+            packets_per_notification=prn,
             inter_packet_delay=inter_packet_delay,
         )
         await dfu.activate_and_reset()

--- a/src/opendisplay/ota.py
+++ b/src/opendisplay/ota.py
@@ -82,23 +82,18 @@ async def perform_nrf_dfu(
         except Exception:  # noqa: BLE001
             log("Warning: could not read DFU version")
 
-        # Tune the firmware stream for a Bluetooth proxy unless fast. The DFU
-        # Packet characteristic is write-without-response, which a proxy silently
-        # drops when its buffer overruns — and HA may route through a distant/busy
-        # proxy with low throughput. Small PRN batches make the receipt round-trip
-        # pace the sender *adaptively* to the link (a slow proxy returns receipts
-        # slower, throttling us) and fully drain the proxy buffer between batches;
-        # the small inter-packet delay guards the within-batch burst. A direct
-        # connection has real flow control, so fast mode uses the larger default
-        # PRN and no delay.
+        # Over a Bluetooth proxy the DFU Packet characteristic (write-without-
+        # response) is silently dropped if bursted, so pace within each PRN batch.
+        # 0.02s reached 100% through a real proxy at a reasonable speed; a smaller
+        # PRN proved far too slow (receipt round-trips dominate). A direct
+        # connection has real flow control, so fast mode sends unpaced.
         inter_packet_delay = 0.0 if fast else 0.02
-        prn = DEFAULT_PRN if fast else 4
         await dfu.start()
         await dfu.start_dfu(len(zip_info.firmware), TYPE_APPLICATION)
         await dfu.init_dfu(zip_info.init_packet)
         await dfu.send_firmware(
             zip_info.firmware,
-            packets_per_notification=prn,
+            packets_per_notification=DEFAULT_PRN,
             inter_packet_delay=inter_packet_delay,
         )
         await dfu.activate_and_reset()

--- a/src/opendisplay/ota.py
+++ b/src/opendisplay/ota.py
@@ -14,6 +14,8 @@ if TYPE_CHECKING:
 _SILABS_OTA_CONTROL_UUID = "f7bf3564-fb6d-4e53-88a4-5e37e0326063"
 _SILABS_OTA_DATA_UUID = "984227f3-34fc-4045-a5d0-2c581f81a153"
 _SILABS_OTA_CHUNK_SIZE = 244
+_SILABS_APPLOADER_BOOT_DELAY = 6.0  # seconds to wait before the first connect
+_SILABS_CONNECT_ATTEMPTS = 5  # establish_connection retries while AppLoader boots
 
 
 async def perform_nrf_dfu(
@@ -86,11 +88,18 @@ async def perform_silabs_ota(
     """Flash an EFR32BG22 device using Silicon Labs AppLoader OTA.
 
     Call ``OpenDisplayDevice.trigger_dfu_bootloader()`` first. This function
-    retries the connection for up to 20 s waiting for the AppLoader to boot —
-    no external sleep is required before calling.
+    retries the *connection* while the AppLoader boots — no external sleep is
+    required before calling.
 
     The AppLoader exits back to the application when the BLE connection
-    drops, so the full transfer must complete in a single connection.
+    drops, so the full transfer must complete in a single connection. We
+    therefore only retry failed connects (which do not arm the reboot) and
+    never reconnect once connected.
+
+    Through an ESPHome Bluetooth proxy, clear the proxy's stale per-MAC GATT
+    cache *before* this call — while still connected in app mode — via
+    ``OpenDisplayDevice.clear_gatt_cache()``, so this connection re-discovers
+    the AppLoader's OTA service instead of the cached app-firmware table.
 
     Args:
         gbl_bytes: Raw .gbl firmware file bytes.
@@ -101,43 +110,73 @@ async def perform_silabs_ota(
     Raises:
         OTAError: OTA transfer failed or AppLoader did not appear within 20 s.
     """
-    from bleak import BleakClient
+    from bleak_retry_connector import BleakClientWithServiceCache, establish_connection
 
     log = on_log or (lambda _: None)
     file_size = len(gbl_bytes)
 
-    # Brief pause to let the device finish rebooting into AppLoader before we
-    # attempt a connection. The AppLoader waits indefinitely once running.
+    # Brief pause to let the device begin booting into AppLoader before the
+    # first connection attempt. establish_connection then retries the connect
+    # itself (max_attempts) — failed/incomplete connects are harmless because
+    # the AppLoader only arms its reboot-on-disconnect after a *successful*
+    # connection. We therefore retry the connect but NEVER reconnect once
+    # connected: this single connection is our only chance to flash.
     log("Waiting for AppLoader to boot…")
-    await asyncio.sleep(6.0)
+    await asyncio.sleep(_SILABS_APPLOADER_BOOT_DELAY)
 
     try:
-        async with BleakClient(ble_device, timeout=20.0) as client:
-            char_uuids = {str(c.uuid).lower() for svc in client.services for c in svc.characteristics}
-            if _SILABS_OTA_CONTROL_UUID not in char_uuids:
-                raise OTAError(
-                    "Device is not in Silabs OTA mode — AppLoader characteristic not found after GATT rediscovery"
-                )
+        # use_services_cache=False forces a fresh GATT discovery rather than
+        # reusing the app-firmware service table. On an ESPHome Bluetooth proxy
+        # the stale per-MAC GATT cache must additionally be cleared on the proxy
+        # *before* this call (while still connected in app mode) via
+        # OpenDisplayDevice.clear_gatt_cache(); see that method.
+        client = await establish_connection(
+            BleakClientWithServiceCache,
+            ble_device,
+            ble_device.name or "AppLoader",
+            use_services_cache=False,
+            max_attempts=_SILABS_CONNECT_ATTEMPTS,
+        )
+    except Exception as exc:
+        raise OTAError(f"Could not connect to AppLoader: {exc}") from exc
 
-            log("Connected to AppLoader. Starting OTA transfer…")
-            await client.write_gatt_char(_SILABS_OTA_CONTROL_UUID, bytearray([0x00]), response=True)
+    try:
+        # Identify the OTA service by its control/data characteristics rather
+        # than the service UUID, which varies between AppLoader builds.
+        char_uuids = {str(c.uuid).lower() for svc in client.services for c in svc.characteristics}
+        if _SILABS_OTA_CONTROL_UUID not in char_uuids or _SILABS_OTA_DATA_UUID not in char_uuids:
+            raise OTAError(
+                "Device is not in Silabs OTA mode — AppLoader OTA characteristics "
+                "not found. Cannot recover on this connection (reconnecting would "
+                "reboot the device out of OTA mode); re-trigger the bootloader and retry."
+            )
 
-            sent = 0
-            while sent < file_size:
-                chunk = gbl_bytes[sent : sent + _SILABS_OTA_CHUNK_SIZE]
-                await client.write_gatt_char(_SILABS_OTA_DATA_UUID, chunk, response=False)
-                sent += len(chunk)
-                if on_progress:
-                    on_progress(sent / file_size * 100)
+        log("Connected to AppLoader. Starting OTA transfer…")
+        await client.write_gatt_char(_SILABS_OTA_CONTROL_UUID, bytearray([0x00]), response=True)
 
-            log("Stream complete. Finalizing…")
-            await client.write_gatt_char(_SILABS_OTA_CONTROL_UUID, bytearray([0x03]), response=True)
-            log("OTA complete — device is verifying and rebooting.")
+        sent = 0
+        while sent < file_size:
+            chunk = gbl_bytes[sent : sent + _SILABS_OTA_CHUNK_SIZE]
+            await client.write_gatt_char(_SILABS_OTA_DATA_UUID, chunk, response=False)
+            sent += len(chunk)
+            if on_progress:
+                on_progress(sent / file_size * 100)
+
+        log("Stream complete. Finalizing…")
+        await client.write_gatt_char(_SILABS_OTA_CONTROL_UUID, bytearray([0x03]), response=True)
+        log("OTA complete — device is verifying and rebooting.")
 
     except OTAError:
         raise
     except Exception as exc:
         raise OTAError(f"Silabs OTA failed: {exc}") from exc
+    finally:
+        # The device reboots out of AppLoader on disconnect anyway; disconnect
+        # explicitly so we don't leak the connection if the transfer raised.
+        try:
+            await client.disconnect()
+        except Exception:  # noqa: BLE001 - best-effort cleanup
+            pass
 
 
 async def find_nrf_dfu_device(original_address: str) -> BLEDevice | None:

--- a/src/opendisplay/ota.py
+++ b/src/opendisplay/ota.py
@@ -16,6 +16,11 @@ _SILABS_OTA_DATA_UUID = "984227f3-34fc-4045-a5d0-2c581f81a153"
 _SILABS_OTA_CHUNK_SIZE = 244
 _SILABS_APPLOADER_BOOT_DELAY = 6.0  # seconds to wait before the first connect
 _SILABS_CONNECT_ATTEMPTS = 5  # establish_connection retries while AppLoader boots
+# Windowed flow control: stream this many data chunks write-without-response
+# (fast), then force one write-with-response whose ATT ack drains the queue.
+# Bounds in-flight writes so we never overrun a BT proxy, but only pay the
+# round-trip latency once per window. Analogous to nRF DFU's PRN (≈8–10).
+_SILABS_OTA_WINDOW = 8
 
 
 async def perform_nrf_dfu(
@@ -154,17 +159,25 @@ async def perform_silabs_ota(
         log("Connected to AppLoader. Starting OTA transfer…")
         await client.write_gatt_char(_SILABS_OTA_CONTROL_UUID, bytearray([0x00]), response=True)
 
+        # Windowed flow control. Write-without-response is fire-and-forget over an
+        # ESPHome BT proxy (no backpressure): feeding it the whole image faster
+        # than it forwards over BLE overruns it and the link drops before finalize.
+        # Fully synchronous writes (response on every chunk) avoid that but are
+        # painfully slow (a round-trip per chunk through the proxy). Instead we
+        # stream a window of chunks write-without-response, then force one
+        # write-with-response whose ATT ack drains the proxy's queue — bounding
+        # in-flight writes while paying the latency only once per window. The
+        # final chunk is always synced so the data is acked before the 0x03
+        # finalize. (Same idea as nRF DFU's PRN, but the Silabs AppLoader has no
+        # receipt-notification characteristic, so the ATT ack is the sync point.)
         sent = 0
+        index = 0
         while sent < file_size:
             chunk = gbl_bytes[sent : sent + _SILABS_OTA_CHUNK_SIZE]
-            # Write WITH response: each chunk round-trips to the device, which
-            # paces the stream to the BLE link speed and provides backpressure.
-            # Write-without-response is fire-and-forget over an ESPHome BT proxy
-            # (no backpressure) — the proxy is fed faster than it can forward
-            # over BLE, the device never receives the full image, and the link
-            # drops before finalize ("Not connected"). response=True avoids that.
-            await client.write_gatt_char(_SILABS_OTA_DATA_UUID, chunk, response=True)
             sent += len(chunk)
+            index += 1
+            sync = index % _SILABS_OTA_WINDOW == 0 or sent >= file_size
+            await client.write_gatt_char(_SILABS_OTA_DATA_UUID, chunk, response=sync)
             if on_progress:
                 on_progress(sent / file_size * 100)
 

--- a/src/opendisplay/ota.py
+++ b/src/opendisplay/ota.py
@@ -16,18 +16,21 @@ _SILABS_OTA_DATA_UUID = "984227f3-34fc-4045-a5d0-2c581f81a153"
 _SILABS_OTA_CHUNK_SIZE = 244
 _SILABS_APPLOADER_BOOT_DELAY = 6.0  # seconds to wait before the first connect
 _SILABS_CONNECT_ATTEMPTS = 5  # establish_connection retries while AppLoader boots
-# Windowed flow control: stream this many data chunks write-without-response
-# (fast), then force one write-with-response whose ATT ack makes the AppLoader
-# drain/process the batch before we send more. Bounds the in-flight writes.
+# Window of data chunks sent write-without-response before forcing one
+# write-with-response (whose ATT ack gates the sender).
 #
-# Kept SMALL: unlike the nRF bootloader (which has a packet-receipt notification
-# to truly gate the sender, allowing PRN≈8-10), the Silabs AppLoader has no such
-# flow control. Over a BT proxy the ESP forwards the whole burst with no
-# backpressure, and a deep window overruns the AppLoader's buffer mid-stream —
-# it stops responding and the next sync write times out (observed: stalled ~20%
-# with window=8). A window of 2 keeps the AppLoader caught up. On direct BlueZ
-# any value works (the link layer paces write-without-response).
-_SILABS_OTA_WINDOW = 2
+# Set to 1 = EVERY chunk is write-with-response. This is required for reliability
+# over a BT proxy: write-without-response (ATT Write Command) has no delivery
+# guarantee — if the device's buffer is briefly full it SILENTLY DROPS the chunk
+# (no ack, no error). Over a proxy (no backpressure) some chunks get dropped, the
+# stream still "completes" (the periodic sync writes are acked), but the image is
+# incomplete and the 0x03 finalize fails verification with "Application error"
+# (observed: window=8 stalled ~20% from buffer overrun; window=2 reached 100% but
+# finalize rejected the gappy image). The Silabs AppLoader has no packet-receipt
+# mechanism to detect/recover drops, so the only safe option is to acknowledge
+# every write. Slower, but it guarantees a complete image. (>1 is only safe on a
+# direct connection, where the link layer makes Write Commands reliable.)
+_SILABS_OTA_WINDOW = 1
 # Adaptive flow control: a BT proxy returns "Congested" when its BLE TX buffer
 # fills under the write-without-response burst (worse on a weak/busy link). It
 # means "slow down", not failure — back off and resend the same chunk.

--- a/src/opendisplay/ota.py
+++ b/src/opendisplay/ota.py
@@ -78,6 +78,8 @@ async def perform_silabs_ota(
     ble_device: BLEDevice,
     on_progress: Callable[[float], None] | None = None,
     on_log: Callable[[str], None] | None = None,
+    *,
+    fast: bool = False,
 ) -> None:
     """Flash an EFR32 device in the Silicon Labs AppLoader (delegates to silabs-ble-ota).
 
@@ -96,6 +98,9 @@ async def perform_silabs_ota(
         ble_device: BLE device in (or booting into) the AppLoader.
         on_progress: Optional callback with float percentage 0–100.
         on_log: Optional callback for human-readable status messages.
+        fast: Use the faster write-without-response transfer. Only safe on a
+            direct connection (no Bluetooth proxy). Leave ``False`` when flashing
+            through an ESPHome Bluetooth proxy. Defaults to ``False``.
 
     Raises:
         OTAError: silabs-ble-ota is not installed, or the OTA failed.
@@ -109,7 +114,7 @@ async def perform_silabs_ota(
         ) from exc
 
     try:
-        await _perform_silabs_ota(gbl_bytes, ble_device, on_progress, on_log)
+        await _perform_silabs_ota(gbl_bytes, ble_device, on_progress, on_log, fast=fast)
     except SilabsOTAError as exc:
         raise OTAError(str(exc)) from exc
 

--- a/src/opendisplay/ota.py
+++ b/src/opendisplay/ota.py
@@ -157,7 +157,13 @@ async def perform_silabs_ota(
         sent = 0
         while sent < file_size:
             chunk = gbl_bytes[sent : sent + _SILABS_OTA_CHUNK_SIZE]
-            await client.write_gatt_char(_SILABS_OTA_DATA_UUID, chunk, response=False)
+            # Write WITH response: each chunk round-trips to the device, which
+            # paces the stream to the BLE link speed and provides backpressure.
+            # Write-without-response is fire-and-forget over an ESPHome BT proxy
+            # (no backpressure) — the proxy is fed faster than it can forward
+            # over BLE, the device never receives the full image, and the link
+            # drops before finalize ("Not connected"). response=True avoids that.
+            await client.write_gatt_char(_SILABS_OTA_DATA_UUID, chunk, response=True)
             sent += len(chunk)
             if on_progress:
                 on_progress(sent / file_size * 100)

--- a/src/opendisplay/ota.py
+++ b/src/opendisplay/ota.py
@@ -17,10 +17,17 @@ _SILABS_OTA_CHUNK_SIZE = 244
 _SILABS_APPLOADER_BOOT_DELAY = 6.0  # seconds to wait before the first connect
 _SILABS_CONNECT_ATTEMPTS = 5  # establish_connection retries while AppLoader boots
 # Windowed flow control: stream this many data chunks write-without-response
-# (fast), then force one write-with-response whose ATT ack drains the queue.
-# Bounds in-flight writes so we never overrun a BT proxy, but only pay the
-# round-trip latency once per window. Analogous to nRF DFU's PRN (≈8–10).
-_SILABS_OTA_WINDOW = 8
+# (fast), then force one write-with-response whose ATT ack makes the AppLoader
+# drain/process the batch before we send more. Bounds the in-flight writes.
+#
+# Kept SMALL: unlike the nRF bootloader (which has a packet-receipt notification
+# to truly gate the sender, allowing PRN≈8-10), the Silabs AppLoader has no such
+# flow control. Over a BT proxy the ESP forwards the whole burst with no
+# backpressure, and a deep window overruns the AppLoader's buffer mid-stream —
+# it stops responding and the next sync write times out (observed: stalled ~20%
+# with window=8). A window of 2 keeps the AppLoader caught up. On direct BlueZ
+# any value works (the link layer paces write-without-response).
+_SILABS_OTA_WINDOW = 2
 # Adaptive flow control: a BT proxy returns "Congested" when its BLE TX buffer
 # fills under the write-without-response burst (worse on a weak/busy link). It
 # means "slow down", not failure — back off and resend the same chunk.

--- a/src/opendisplay/ota.py
+++ b/src/opendisplay/ota.py
@@ -21,6 +21,11 @@ _SILABS_CONNECT_ATTEMPTS = 5  # establish_connection retries while AppLoader boo
 # Bounds in-flight writes so we never overrun a BT proxy, but only pay the
 # round-trip latency once per window. Analogous to nRF DFU's PRN (≈8–10).
 _SILABS_OTA_WINDOW = 8
+# Adaptive flow control: a BT proxy returns "Congested" when its BLE TX buffer
+# fills under the write-without-response burst (worse on a weak/busy link). It
+# means "slow down", not failure — back off and resend the same chunk.
+_SILABS_OTA_CONGESTION_RETRIES = 6
+_SILABS_OTA_CONGESTION_BACKOFF = 0.15  # seconds, to let the proxy queue drain
 
 
 async def perform_nrf_dfu(
@@ -177,7 +182,18 @@ async def perform_silabs_ota(
             sent += len(chunk)
             index += 1
             sync = index % _SILABS_OTA_WINDOW == 0 or sent >= file_size
-            await client.write_gatt_char(_SILABS_OTA_DATA_UUID, chunk, response=sync)
+            # Resend on proxy congestion ("Congested" = ESP TX buffer full): the
+            # write hasn't been delivered, so back off briefly and retry the same
+            # chunk rather than abort the transfer.
+            for congestion_attempt in range(_SILABS_OTA_CONGESTION_RETRIES):
+                try:
+                    await client.write_gatt_char(_SILABS_OTA_DATA_UUID, chunk, response=sync)
+                    break
+                except Exception as exc:  # noqa: BLE001 - inspect message for congestion
+                    is_congested = "congest" in str(exc).lower()
+                    if not is_congested or congestion_attempt == _SILABS_OTA_CONGESTION_RETRIES - 1:
+                        raise
+                    await asyncio.sleep(_SILABS_OTA_CONGESTION_BACKOFF)
             if on_progress:
                 on_progress(sent / file_size * 100)
 

--- a/src/opendisplay/ota.py
+++ b/src/opendisplay/ota.py
@@ -35,7 +35,7 @@ async def perform_nrf_dfu(
         OTAError: DFU transfer failed or DFU service not present.
     """
     try:
-        from bleak import BleakClient
+        from bleak_retry_connector import BleakClientWithServiceCache, establish_connection
         from nrf_ota._const import DEFAULT_PRN, LEGACY_DFU_SERVICE_UUID, TYPE_APPLICATION
         from nrf_ota._zip import _parse_zip_bytes
         from nrf_ota.dfu import LegacyDFU
@@ -45,32 +45,54 @@ async def perform_nrf_dfu(
     log = on_log or (lambda _: None)
     zip_info = _parse_zip_bytes(zip_bytes)
 
+    # Connect through bleak-retry-connector so the DFU transfer works over an
+    # ESPHome Bluetooth proxy too — a plain BleakClient only connects via a local
+    # adapter, which is why this previously failed on HA OS but worked on a dev
+    # Mac. use_services_cache=False forces a fresh GATT discovery: the DFU
+    # bootloader exposes a different service table than the application.
     try:
-        async with BleakClient(dfu_ble_device) as client:
-            svc_uuids = [str(s.uuid).lower() for s in client.services]
-            log(f"DFU device services: {svc_uuids}")
+        client = await establish_connection(
+            BleakClientWithServiceCache,
+            dfu_ble_device,
+            dfu_ble_device.name or "nRF DFU",
+            use_services_cache=False,
+            max_attempts=4,
+        )
+    except Exception as exc:  # noqa: BLE001 - surfaced as OTAError
+        raise OTAError(f"Could not connect to nRF DFU bootloader: {exc}") from exc
 
-            if not any(s == LEGACY_DFU_SERVICE_UUID.lower() for s in svc_uuids):
-                raise OTAError(f"Device is not in Nordic Legacy DFU mode. Services found: {svc_uuids}")
+    try:
+        svc_uuids = [str(s.uuid).lower() for s in client.services]
+        log(f"DFU device services: {svc_uuids}")
 
-            dfu = LegacyDFU(client, on_progress=on_progress, on_log=log)
-            try:
-                major, minor = await dfu.read_version()
-                log(f"DFU bootloader version: {major}.{minor}")
-            except Exception:  # noqa: BLE001
-                log("Warning: could not read DFU version")
+        if not any(s == LEGACY_DFU_SERVICE_UUID.lower() for s in svc_uuids):
+            raise OTAError(f"Device is not in Nordic Legacy DFU mode. Services found: {svc_uuids}")
 
-            await dfu.start()
-            await dfu.start_dfu(len(zip_info.firmware), TYPE_APPLICATION)
-            await dfu.init_dfu(zip_info.init_packet)
-            await dfu.send_firmware(zip_info.firmware, packets_per_notification=DEFAULT_PRN)
-            await dfu.activate_and_reset()
-            log("DFU complete — device is rebooting with new firmware.")
+        dfu = LegacyDFU(client, on_progress=on_progress, on_log=log)
+        try:
+            major, minor = await dfu.read_version()
+            log(f"DFU bootloader version: {major}.{minor}")
+        except Exception:  # noqa: BLE001
+            log("Warning: could not read DFU version")
+
+        await dfu.start()
+        await dfu.start_dfu(len(zip_info.firmware), TYPE_APPLICATION)
+        await dfu.init_dfu(zip_info.init_packet)
+        await dfu.send_firmware(zip_info.firmware, packets_per_notification=DEFAULT_PRN)
+        await dfu.activate_and_reset()
+        log("DFU complete — device is rebooting with new firmware.")
 
     except OTAError:
         raise
-    except Exception as exc:
+    except Exception as exc:  # noqa: BLE001 - surfaced as OTAError
         raise OTAError(f"nRF DFU failed: {exc}") from exc
+    finally:
+        # The device reboots out of DFU on activate/disconnect anyway; disconnect
+        # explicitly so we don't leak the connection if the transfer raised.
+        try:
+            await client.disconnect()
+        except Exception:  # noqa: BLE001 - best-effort cleanup
+            pass
 
 
 async def perform_silabs_ota(

--- a/src/opendisplay/ota.py
+++ b/src/opendisplay/ota.py
@@ -11,32 +11,6 @@ from .exceptions import OTAError
 if TYPE_CHECKING:
     from bleak.backends.device import BLEDevice
 
-_SILABS_OTA_CONTROL_UUID = "f7bf3564-fb6d-4e53-88a4-5e37e0326063"
-_SILABS_OTA_DATA_UUID = "984227f3-34fc-4045-a5d0-2c581f81a153"
-_SILABS_OTA_CHUNK_SIZE = 244
-_SILABS_APPLOADER_BOOT_DELAY = 6.0  # seconds to wait before the first connect
-_SILABS_CONNECT_ATTEMPTS = 5  # establish_connection retries while AppLoader boots
-# Window of data chunks sent write-without-response before forcing one
-# write-with-response (whose ATT ack gates the sender).
-#
-# Set to 1 = EVERY chunk is write-with-response. This is required for reliability
-# over a BT proxy: write-without-response (ATT Write Command) has no delivery
-# guarantee — if the device's buffer is briefly full it SILENTLY DROPS the chunk
-# (no ack, no error). Over a proxy (no backpressure) some chunks get dropped, the
-# stream still "completes" (the periodic sync writes are acked), but the image is
-# incomplete and the 0x03 finalize fails verification with "Application error"
-# (observed: window=8 stalled ~20% from buffer overrun; window=2 reached 100% but
-# finalize rejected the gappy image). The Silabs AppLoader has no packet-receipt
-# mechanism to detect/recover drops, so the only safe option is to acknowledge
-# every write. Slower, but it guarantees a complete image. (>1 is only safe on a
-# direct connection, where the link layer makes Write Commands reliable.)
-_SILABS_OTA_WINDOW = 1
-# Adaptive flow control: a BT proxy returns "Congested" when its BLE TX buffer
-# fills under the write-without-response burst (worse on a weak/busy link). It
-# means "slow down", not failure — back off and resend the same chunk.
-_SILABS_OTA_CONGESTION_RETRIES = 6
-_SILABS_OTA_CONGESTION_BACKOFF = 0.15  # seconds, to let the proxy queue drain
-
 
 async def perform_nrf_dfu(
     zip_bytes: bytes,
@@ -105,123 +79,39 @@ async def perform_silabs_ota(
     on_progress: Callable[[float], None] | None = None,
     on_log: Callable[[str], None] | None = None,
 ) -> None:
-    """Flash an EFR32BG22 device using Silicon Labs AppLoader OTA.
+    """Flash an EFR32 device in the Silicon Labs AppLoader (delegates to silabs-ble-ota).
 
-    Call ``OpenDisplayDevice.trigger_dfu_bootloader()`` first. This function
-    retries the *connection* while the AppLoader boots — no external sleep is
-    required before calling.
+    Thin wrapper over the standalone :mod:`silabs_ble_ota` library (an optional
+    dependency, installed via the ``silabs-ota`` extra), mirroring how
+    :func:`perform_nrf_dfu` wraps ``nrf-ota``.
 
-    The AppLoader exits back to the application when the BLE connection
-    drops, so the full transfer must complete in a single connection. We
-    therefore only retry failed connects (which do not arm the reboot) and
-    never reconnect once connected.
-
-    Through an ESPHome Bluetooth proxy, clear the proxy's stale per-MAC GATT
-    cache *before* this call — while still connected in app mode — via
-    ``OpenDisplayDevice.clear_gatt_cache()``, so this connection re-discovers
-    the AppLoader's OTA service instead of the cached app-firmware table.
+    Call ``OpenDisplayDevice.trigger_dfu_bootloader()`` first, then pass the
+    AppLoader's ``BLEDevice`` (same address as app mode). Over an ESPHome
+    Bluetooth proxy, clear the proxy's stale per-MAC GATT cache first via
+    ``OpenDisplayDevice.clear_gatt_cache()`` so this connection re-discovers the
+    AppLoader's OTA service instead of the cached app-firmware table.
 
     Args:
         gbl_bytes: Raw .gbl firmware file bytes.
-        ble_device: BLE device (same address as app mode).
+        ble_device: BLE device in (or booting into) the AppLoader.
         on_progress: Optional callback with float percentage 0–100.
         on_log: Optional callback for human-readable status messages.
 
     Raises:
-        OTAError: OTA transfer failed or AppLoader did not appear within 20 s.
+        OTAError: silabs-ble-ota is not installed, or the OTA failed.
     """
-    from bleak_retry_connector import BleakClientWithServiceCache, establish_connection
-
-    log = on_log or (lambda _: None)
-    file_size = len(gbl_bytes)
-
-    # Brief pause to let the device begin booting into AppLoader before the
-    # first connection attempt. establish_connection then retries the connect
-    # itself (max_attempts) — failed/incomplete connects are harmless because
-    # the AppLoader only arms its reboot-on-disconnect after a *successful*
-    # connection. We therefore retry the connect but NEVER reconnect once
-    # connected: this single connection is our only chance to flash.
-    log("Waiting for AppLoader to boot…")
-    await asyncio.sleep(_SILABS_APPLOADER_BOOT_DELAY)
+    try:
+        from silabs_ble_ota import SilabsOTAError
+        from silabs_ble_ota import perform_silabs_ota as _perform_silabs_ota
+    except ImportError as exc:
+        raise OTAError(
+            "silabs-ble-ota is required for Silabs firmware updates; install it with: pip install silabs-ble-ota"
+        ) from exc
 
     try:
-        # use_services_cache=False forces a fresh GATT discovery rather than
-        # reusing the app-firmware service table. On an ESPHome Bluetooth proxy
-        # the stale per-MAC GATT cache must additionally be cleared on the proxy
-        # *before* this call (while still connected in app mode) via
-        # OpenDisplayDevice.clear_gatt_cache(); see that method.
-        client = await establish_connection(
-            BleakClientWithServiceCache,
-            ble_device,
-            ble_device.name or "AppLoader",
-            use_services_cache=False,
-            max_attempts=_SILABS_CONNECT_ATTEMPTS,
-        )
-    except Exception as exc:
-        raise OTAError(f"Could not connect to AppLoader: {exc}") from exc
-
-    try:
-        # Identify the OTA service by its control/data characteristics rather
-        # than the service UUID, which varies between AppLoader builds.
-        char_uuids = {str(c.uuid).lower() for svc in client.services for c in svc.characteristics}
-        if _SILABS_OTA_CONTROL_UUID not in char_uuids or _SILABS_OTA_DATA_UUID not in char_uuids:
-            raise OTAError(
-                "Device is not in Silabs OTA mode — AppLoader OTA characteristics "
-                "not found. Cannot recover on this connection (reconnecting would "
-                "reboot the device out of OTA mode); re-trigger the bootloader and retry."
-            )
-
-        log("Connected to AppLoader. Starting OTA transfer…")
-        await client.write_gatt_char(_SILABS_OTA_CONTROL_UUID, bytearray([0x00]), response=True)
-
-        # Windowed flow control. Write-without-response is fire-and-forget over an
-        # ESPHome BT proxy (no backpressure): feeding it the whole image faster
-        # than it forwards over BLE overruns it and the link drops before finalize.
-        # Fully synchronous writes (response on every chunk) avoid that but are
-        # painfully slow (a round-trip per chunk through the proxy). Instead we
-        # stream a window of chunks write-without-response, then force one
-        # write-with-response whose ATT ack drains the proxy's queue — bounding
-        # in-flight writes while paying the latency only once per window. The
-        # final chunk is always synced so the data is acked before the 0x03
-        # finalize. (Same idea as nRF DFU's PRN, but the Silabs AppLoader has no
-        # receipt-notification characteristic, so the ATT ack is the sync point.)
-        sent = 0
-        index = 0
-        while sent < file_size:
-            chunk = gbl_bytes[sent : sent + _SILABS_OTA_CHUNK_SIZE]
-            sent += len(chunk)
-            index += 1
-            sync = index % _SILABS_OTA_WINDOW == 0 or sent >= file_size
-            # Resend on proxy congestion ("Congested" = ESP TX buffer full): the
-            # write hasn't been delivered, so back off briefly and retry the same
-            # chunk rather than abort the transfer.
-            for congestion_attempt in range(_SILABS_OTA_CONGESTION_RETRIES):
-                try:
-                    await client.write_gatt_char(_SILABS_OTA_DATA_UUID, chunk, response=sync)
-                    break
-                except Exception as exc:  # noqa: BLE001 - inspect message for congestion
-                    is_congested = "congest" in str(exc).lower()
-                    if not is_congested or congestion_attempt == _SILABS_OTA_CONGESTION_RETRIES - 1:
-                        raise
-                    await asyncio.sleep(_SILABS_OTA_CONGESTION_BACKOFF)
-            if on_progress:
-                on_progress(sent / file_size * 100)
-
-        log("Stream complete. Finalizing…")
-        await client.write_gatt_char(_SILABS_OTA_CONTROL_UUID, bytearray([0x03]), response=True)
-        log("OTA complete — device is verifying and rebooting.")
-
-    except OTAError:
-        raise
-    except Exception as exc:
-        raise OTAError(f"Silabs OTA failed: {exc}") from exc
-    finally:
-        # The device reboots out of AppLoader on disconnect anyway; disconnect
-        # explicitly so we don't leak the connection if the transfer raised.
-        try:
-            await client.disconnect()
-        except Exception:  # noqa: BLE001 - best-effort cleanup
-            pass
+        await _perform_silabs_ota(gbl_bytes, ble_device, on_progress, on_log)
+    except SilabsOTAError as exc:
+        raise OTAError(str(exc)) from exc
 
 
 async def find_nrf_dfu_device(original_address: str) -> BLEDevice | None:

--- a/src/opendisplay/ota.py
+++ b/src/opendisplay/ota.py
@@ -17,6 +17,8 @@ async def perform_nrf_dfu(
     dfu_ble_device: BLEDevice,
     on_progress: Callable[[float], None] | None = None,
     on_log: Callable[[str], None] | None = None,
+    *,
+    fast: bool = False,
 ) -> None:
     """Flash an nRF device that is already in Nordic Legacy DFU mode.
 
@@ -30,6 +32,11 @@ async def perform_nrf_dfu(
         dfu_ble_device: BLE device already in DFU mode.
         on_progress: Optional callback with float percentage 0–100.
         on_log: Optional callback for human-readable status messages.
+        fast: Stream firmware packets unpaced for a much faster transfer. Only
+            safe on a direct connection — over an ESPHome Bluetooth proxy the
+            unpaced write-without-response burst is silently dropped and the DFU
+            stalls. Leave ``False`` (paced) when flashing through a proxy, which
+            is always the case on HA OS. Defaults to ``False``.
 
     Raises:
         OTAError: DFU transfer failed or DFU service not present.
@@ -75,10 +82,19 @@ async def perform_nrf_dfu(
         except Exception:  # noqa: BLE001
             log("Warning: could not read DFU version")
 
+        # Pace packets within each PRN batch unless fast: the DFU Packet
+        # characteristic is write-without-response, which a Bluetooth proxy can
+        # silently drop when bursted (0.02s ≈ one packet per connection interval,
+        # the rate init_dfu already uses successfully through a proxy).
+        inter_packet_delay = 0.0 if fast else 0.02
         await dfu.start()
         await dfu.start_dfu(len(zip_info.firmware), TYPE_APPLICATION)
         await dfu.init_dfu(zip_info.init_packet)
-        await dfu.send_firmware(zip_info.firmware, packets_per_notification=DEFAULT_PRN)
+        await dfu.send_firmware(
+            zip_info.firmware,
+            packets_per_notification=DEFAULT_PRN,
+            inter_packet_delay=inter_packet_delay,
+        )
         await dfu.activate_and_reset()
         log("DFU complete — device is rebooting with new firmware.")
 

--- a/src/opendisplay/transport/connection.py
+++ b/src/opendisplay/transport/connection.py
@@ -133,6 +133,33 @@ class BLEConnection:
             finally:
                 self._client = None
 
+    async def clear_cache(self) -> bool:
+        """Clear the GATT services cache for this device.
+
+        On an ESPHome Bluetooth proxy this clears the proxy's cached per-MAC
+        GATT table so the next connection re-discovers services — needed when
+        the device's GATT changes without changing address (e.g. rebooting into
+        the Silabs AppLoader for OTA). Requires an active connection; the
+        on-device clear only works if the proxy firmware supports it (otherwise
+        only the in-memory cache is cleared).
+
+        Returns:
+            True if a cache was cleared, False if the backend has no cache
+            support (e.g. direct BlueZ on a bleak build without ``clear_cache``).
+
+        Raises:
+            BLEConnectionError: If not connected.
+        """
+        if not self._client or not self._client.is_connected:
+            raise BLEConnectionError("Not connected")
+        # The concrete client (BleakClientWithServiceCache) has clear_cache, but
+        # the declared BleakClient type does not — resolve it dynamically.
+        clear_cache_fn = getattr(self._client, "clear_cache", None)
+        if not callable(clear_cache_fn):
+            return False
+        # Guarded by callable() above; pylint can't infer through getattr.
+        return bool(await clear_cache_fn())  # pylint: disable=not-callable
+
     async def _setup_notifications(self) -> None:
         """Set up BLE notifications for responses.
 

--- a/src/opendisplay/transport/connection.py
+++ b/src/opendisplay/transport/connection.py
@@ -84,43 +84,86 @@ class BLEConnection:
             return  # Already connected
 
         try:
-            _LOGGER.debug(
-                "Connecting to %s with bleak-retry-connector (max_attempts=%d)", self.mac_address, self.max_attempts
-            )
-
-            # Resolve MAC to BLEDevice if not provided
-            if self.ble_device:
-                device = self.ble_device
-            else:
-                # For MAC-only usage, scan for the device
-                found_device: BLEDevice | None = await BleakScanner.find_device_by_address(
-                    self.mac_address, timeout=self.timeout
-                )
-                if found_device is None:
-                    raise BLEConnectionError(f"Device {self.mac_address} not found during scan")
-                device = found_device
-
-            self.device_name = device.name
-
-            # Establish connection with retry logic
-            self._client = await establish_connection(
-                client_class=BleakClientWithServiceCache,
-                device=device,
-                name=device.name or self.mac_address,
-                max_attempts=self.max_attempts,
-                use_services_cache=self.use_services_cache,
-                timeout=self.timeout,
-            )
-
-            _LOGGER.debug("Connected to %s", self.mac_address)
-
-            # Start notifications
-            await self._setup_notifications()
-
+            await self._attempt_connect(use_services_cache=self.use_services_cache)
         except asyncio.TimeoutError as e:
             raise BLETimeoutError(f"Connection timeout after {self.timeout}s") from e
+        except BLEConnectionError as e:
+            # A stale Bluetooth-proxy GATT cache can make the expected service
+            # appear missing — e.g. after the device was last seen in the DFU/OTA
+            # bootloader, the proxy keeps serving the bootloader's GATT for this
+            # MAC. Clear the proxy cache and retry once with fresh discovery
+            # before giving up. (Only for the service-missing case; a plain
+            # "device not found during scan" is re-raised unchanged.)
+            if SERVICE_UUID.lower() not in str(e).lower():
+                raise
+            _LOGGER.debug(
+                "Connect to %s failed (%s); clearing GATT cache and retrying once",
+                self.mac_address,
+                e,
+            )
+            await self._clear_cache_and_drop()
+            try:
+                await self._attempt_connect(use_services_cache=False)
+            except asyncio.TimeoutError as e2:
+                raise BLETimeoutError(f"Connection timeout after {self.timeout}s") from e2
+            except Exception as e2:
+                raise BLEConnectionError(f"Failed to connect: {e2}") from e2
         except Exception as e:
             raise BLEConnectionError(f"Failed to connect: {e}") from e
+
+    async def _attempt_connect(self, *, use_services_cache: bool) -> None:
+        """Resolve the device, establish a connection, and set up notifications."""
+        _LOGGER.debug(
+            "Connecting to %s with bleak-retry-connector (max_attempts=%d, use_services_cache=%s)",
+            self.mac_address,
+            self.max_attempts,
+            use_services_cache,
+        )
+
+        # Resolve MAC to BLEDevice if not provided
+        if self.ble_device:
+            device = self.ble_device
+        else:
+            # For MAC-only usage, scan for the device
+            found_device: BLEDevice | None = await BleakScanner.find_device_by_address(
+                self.mac_address, timeout=self.timeout
+            )
+            if found_device is None:
+                raise BLEConnectionError(f"Device {self.mac_address} not found during scan")
+            device = found_device
+
+        self.device_name = device.name
+
+        # Establish connection with retry logic
+        self._client = await establish_connection(
+            client_class=BleakClientWithServiceCache,
+            device=device,
+            name=device.name or self.mac_address,
+            max_attempts=self.max_attempts,
+            use_services_cache=use_services_cache,
+            timeout=self.timeout,
+        )
+
+        _LOGGER.debug("Connected to %s", self.mac_address)
+
+        # Start notifications
+        await self._setup_notifications()
+
+    async def _clear_cache_and_drop(self) -> None:
+        """Clear the proxy GATT cache on the current client, then disconnect it."""
+        if self._client is None:
+            return
+        clear = getattr(self._client, "clear_cache", None)
+        if callable(clear):
+            try:
+                await clear()  # pylint: disable=not-callable
+            except Exception as err:  # noqa: BLE001 - best-effort
+                _LOGGER.debug("clear_cache during connect retry failed: %s", err)
+        try:
+            await self._client.disconnect()
+        except Exception:  # noqa: BLE001
+            pass
+        self._client = None
 
     async def disconnect(self) -> None:
         """Disconnect from device."""

--- a/tests/unit/test_connection_clear_cache.py
+++ b/tests/unit/test_connection_clear_cache.py
@@ -1,0 +1,77 @@
+"""Tests for GATT cache clearing (BLEConnection.clear_cache + device.clear_gatt_cache).
+
+clear_gatt_cache() is used on the Silabs OTA path to drop a Bluetooth proxy's
+stale per-MAC GATT cache before triggering the bootloader, so the post-reboot
+AppLoader connection re-discovers the OTA service.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from opendisplay import OpenDisplayDevice
+from opendisplay.exceptions import BLEConnectionError
+from opendisplay.transport.connection import BLEConnection
+
+
+def _connected(client: object) -> BLEConnection:
+    conn = BLEConnection("AA:BB:CC:DD:EE:FF")
+    conn._client = client
+    return conn
+
+
+@pytest.mark.asyncio
+async def test_clear_cache_calls_backend_and_returns_result() -> None:
+    """When the backend supports clear_cache, its result is returned."""
+    client = MagicMock(is_connected=True)
+    client.clear_cache = AsyncMock(return_value=True)
+    conn = _connected(client)
+
+    assert await conn.clear_cache() is True
+    client.clear_cache.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+async def test_clear_cache_propagates_false() -> None:
+    """A backend that clears only its in-memory cache returns False through us."""
+    client = MagicMock(is_connected=True)
+    client.clear_cache = AsyncMock(return_value=False)
+    conn = _connected(client)
+
+    assert await conn.clear_cache() is False
+
+
+@pytest.mark.asyncio
+async def test_clear_cache_no_backend_support_returns_false() -> None:
+    """Direct BlueZ on a bleak build without clear_cache: graceful False, no raise."""
+    client = MagicMock(is_connected=True, spec=["is_connected"])  # no clear_cache attr
+    conn = _connected(client)
+
+    assert await conn.clear_cache() is False
+
+
+@pytest.mark.asyncio
+async def test_clear_cache_not_connected_raises() -> None:
+    """clear_cache requires an active connection."""
+    conn = BLEConnection("AA:BB:CC:DD:EE:FF")  # _client is None
+    with pytest.raises(BLEConnectionError, match="Not connected"):
+        await conn.clear_cache()
+
+    client = MagicMock(is_connected=False)
+    conn2 = _connected(client)
+    with pytest.raises(BLEConnectionError, match="Not connected"):
+        await conn2.clear_cache()
+
+
+@pytest.mark.asyncio
+async def test_device_clear_gatt_cache_delegates_to_connection() -> None:
+    """OpenDisplayDevice.clear_gatt_cache() forwards to the connection and returns it."""
+    device = OpenDisplayDevice(mac_address="AA:BB:CC:DD:EE:FF")
+    fake_conn = MagicMock()
+    fake_conn.clear_cache = AsyncMock(return_value=True)
+    device._connection = fake_conn
+
+    assert await device.clear_gatt_cache() is True
+    fake_conn.clear_cache.assert_awaited_once_with()

--- a/tests/unit/test_connection_clear_cache.py
+++ b/tests/unit/test_connection_clear_cache.py
@@ -121,3 +121,47 @@ async def test_device_clear_gatt_cache_delegates_to_connection() -> None:
 
     assert await device.clear_gatt_cache() is True
     fake_conn.clear_cache.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+async def test_trigger_dfu_bootloader_tolerates_write_error() -> None:
+    """The enter-DFU command resets the device before it can ACK, so a write error
+    (e.g. a GATT 133 over a Bluetooth proxy) is expected and tolerated, not raised —
+    whether DFU was entered is determined by the subsequent scan for the DFU device."""
+    device = OpenDisplayDevice(mac_address="AA:BB:CC:DD:EE:FF")
+    device._write = AsyncMock(side_effect=BLEConnectionError("Write failed: ... error=133"))
+
+    await device.trigger_dfu_bootloader()  # must not raise
+    device._write.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_clear_cache_and_drop_clears_then_disconnects() -> None:
+    """The connect-retry helper clears the proxy cache, drops the client, and resets it."""
+    client = AsyncMock(is_connected=True)
+    client.clear_cache = AsyncMock()
+    conn = _connected(client)
+
+    await conn._clear_cache_and_drop()
+
+    client.clear_cache.assert_awaited_once()
+    client.disconnect.assert_awaited_once()
+    assert conn._client is None
+
+
+@pytest.mark.asyncio
+async def test_connect_establishes_and_sets_up_notifications() -> None:
+    """connect() resolves the provided BLEDevice, establishes the client, and notifies."""
+    conn = BLEConnection("AA:BB:CC:DD:EE:FF", ble_device=MagicMock())
+    client = MagicMock(is_connected=False)
+    conn._setup_notifications = AsyncMock()
+
+    with patch(
+        "opendisplay.transport.connection.establish_connection",
+        new=AsyncMock(return_value=client),
+    ) as est:
+        await conn.connect()
+
+    assert conn._client is client
+    conn._setup_notifications.assert_awaited_once()
+    assert est.await_args.kwargs["use_services_cache"] is True

--- a/tests/unit/test_connection_clear_cache.py
+++ b/tests/unit/test_connection_clear_cache.py
@@ -7,7 +7,7 @@ AppLoader connection re-discovers the OTA service.
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -63,6 +63,52 @@ async def test_clear_cache_not_connected_raises() -> None:
     conn2 = _connected(client)
     with pytest.raises(BLEConnectionError, match="Not connected"):
         await conn2.clear_cache()
+
+
+def _client_with_service(has_service: bool) -> MagicMock:
+    """A connected client whose GATT does/doesn't expose the app service."""
+    client = AsyncMock()
+    client.is_connected = True
+    svc = MagicMock()
+    svc.characteristics = [MagicMock()]
+    services = MagicMock()
+    services.get_service.return_value = svc if has_service else None
+    client.services = services
+    return client
+
+
+@pytest.mark.asyncio
+async def test_connect_clears_cache_and_retries_on_stale_service() -> None:
+    """A stale proxy GATT cache (app service missing) → clear_cache + reconnect once."""
+    from opendisplay.transport import connection as conn_mod
+
+    stale = _client_with_service(False)  # proxy serving stale GATT (no app service)
+    fresh = _client_with_service(True)  # fresh discovery after the cache clear
+    clients = [stale, fresh]
+
+    async def fake_establish(*_a, **_k):
+        return clients.pop(0)
+
+    conn = BLEConnection("AA:BB:CC:DD:EE:FF", ble_device=MagicMock())
+    with patch.object(conn_mod, "establish_connection", fake_establish):
+        await conn.connect()
+
+    stale.clear_cache.assert_awaited_once()  # poisoned cache was cleared
+    assert conn._client is fresh  # ended up connected via fresh discovery
+
+
+@pytest.mark.asyncio
+async def test_connect_does_not_retry_on_non_service_error() -> None:
+    """A non-service failure (e.g. device not found) is not retried with a cache clear."""
+    from opendisplay.transport import connection as conn_mod
+
+    async def fake_establish(*_a, **_k):
+        raise RuntimeError("device disconnected")
+
+    conn = BLEConnection("AA:BB:CC:DD:EE:FF", ble_device=MagicMock())
+    with patch.object(conn_mod, "establish_connection", fake_establish):
+        with pytest.raises(BLEConnectionError, match="Failed to connect"):
+            await conn.connect()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_ota.py
+++ b/tests/unit/test_ota.py
@@ -125,6 +125,29 @@ async def test_silabs_ota_windowed_flow_control() -> None:
 
 
 @pytest.mark.asyncio
+async def test_silabs_ota_retries_on_congestion() -> None:
+    """A 'Congested' proxy error on a data write is retried, not fatal."""
+    client = _make_bleak_client([_SILABS_OTA_CONTROL_UUID, _SILABS_OTA_DATA_UUID])
+    fails = {"n": 0}
+
+    async def write(uuid, data, response=False):  # noqa: ARG001
+        if uuid == _SILABS_OTA_DATA_UUID and fails["n"] < 2:
+            fails["n"] += 1
+            raise RuntimeError("Bluetooth GATT Error ... description=Congested")
+
+    client.write_gatt_char = AsyncMock(side_effect=write)
+
+    with (
+        patch("opendisplay.ota.asyncio.sleep", new=AsyncMock()),
+        _patch_connect(client),
+    ):
+        await perform_silabs_ota(b"\x00" * (_SILABS_OTA_CHUNK_SIZE * 2), _make_ble_device())
+
+    # The first data chunk was resent twice (Congested) then succeeded.
+    assert fails["n"] == 2
+
+
+@pytest.mark.asyncio
 async def test_silabs_ota_waits_for_apploader_boot() -> None:
     """perform_silabs_ota waits for the AppLoader to boot before connecting."""
     sleep_mock = AsyncMock()

--- a/tests/unit/test_ota.py
+++ b/tests/unit/test_ota.py
@@ -84,7 +84,8 @@ async def test_silabs_ota_happy_path() -> None:
     total_sent = sum(len(c.args[1]) for c in data_calls)
     assert total_sent == len(gbl)
     assert all(len(c.args[1]) <= _SILABS_OTA_CHUNK_SIZE for c in data_calls)
-    assert all(c.kwargs["response"] is False for c in data_calls)
+    # Write-with-response paces the stream and provides backpressure over BT proxies.
+    assert all(c.kwargs["response"] is True for c in data_calls)
 
     # Last call: OTA finalize (0x03)
     assert calls[-1].args[0] == _SILABS_OTA_CONTROL_UUID

--- a/tests/unit/test_ota.py
+++ b/tests/unit/test_ota.py
@@ -8,6 +8,7 @@ import pytest
 
 from opendisplay.exceptions import OTAError
 from opendisplay.ota import (
+    _SILABS_APPLOADER_BOOT_DELAY,
     _SILABS_OTA_CHUNK_SIZE,
     _SILABS_OTA_CONTROL_UUID,
     _SILABS_OTA_DATA_UUID,
@@ -21,15 +22,27 @@ from opendisplay.ota import (
 
 
 def _make_bleak_client(char_uuids: list[str]) -> MagicMock:
-    """Return a mock BleakClient whose services expose the given char UUIDs."""
+    """Return a mock client (as returned by establish_connection) whose services
+    expose the given char UUIDs. write_gatt_char/disconnect are AsyncMocks."""
     char_mocks = [MagicMock(uuid=uuid) for uuid in char_uuids]
     svc = MagicMock()
     svc.characteristics = char_mocks
     client = AsyncMock()
     client.services = [svc]
-    client.__aenter__ = AsyncMock(return_value=client)
-    client.__aexit__ = AsyncMock(return_value=False)
     return client
+
+
+def _patch_connect(client_or_exc) -> object:
+    """Patch establish_connection to return a client (or raise an exception)."""
+    if isinstance(client_or_exc, BaseException):
+        return patch(
+            "bleak_retry_connector.establish_connection",
+            new=AsyncMock(side_effect=client_or_exc),
+        )
+    return patch(
+        "bleak_retry_connector.establish_connection",
+        new=AsyncMock(return_value=client_or_exc),
+    )
 
 
 def _make_ble_device(address: str = "AA:BB:CC:DD:EE:FF") -> MagicMock:
@@ -45,16 +58,20 @@ def _make_ble_device(address: str = "AA:BB:CC:DD:EE:FF") -> MagicMock:
 
 @pytest.mark.asyncio
 async def test_silabs_ota_happy_path() -> None:
-    """Full OTA transfer: start write, all data chunks, finalize write."""
+    """Full OTA transfer: start write, all data chunks, finalize write, disconnect."""
     gbl = bytes(range(256)) * 2  # 512 bytes → 3 chunks of 244/244/24
     client = _make_bleak_client([_SILABS_OTA_CONTROL_UUID, _SILABS_OTA_DATA_UUID])
     progress: list[float] = []
+    connect = AsyncMock(return_value=client)
 
     with (
         patch("opendisplay.ota.asyncio.sleep", new=AsyncMock()),
-        patch("bleak.BleakClient", return_value=client),
+        patch("bleak_retry_connector.establish_connection", new=connect),
     ):
         await perform_silabs_ota(gbl, _make_ble_device(), on_progress=progress.append)
+
+    # Fresh GATT discovery, not the cached app-firmware service table.
+    assert connect.await_args.kwargs["use_services_cache"] is False
 
     calls = client.write_gatt_char.call_args_list
     # First call: OTA start (0x00)
@@ -78,48 +95,79 @@ async def test_silabs_ota_happy_path() -> None:
     assert progress[0] > 0
     assert progress[-1] == pytest.approx(100.0)
 
+    # The single connection is always closed.
+    client.disconnect.assert_awaited_once()
+
 
 @pytest.mark.asyncio
-async def test_silabs_ota_sleeps_before_connect() -> None:
-    """perform_silabs_ota waits for AppLoader to boot before connecting."""
+async def test_silabs_ota_waits_for_apploader_boot() -> None:
+    """perform_silabs_ota waits for the AppLoader to boot before connecting."""
     sleep_mock = AsyncMock()
     client = _make_bleak_client([_SILABS_OTA_CONTROL_UUID, _SILABS_OTA_DATA_UUID])
 
     with (
         patch("opendisplay.ota.asyncio.sleep", new=sleep_mock),
-        patch("bleak.BleakClient", return_value=client),
+        _patch_connect(client),
     ):
         await perform_silabs_ota(b"\x00" * 10, _make_ble_device())
 
-    sleep_mock.assert_awaited_once_with(6.0)
+    sleep_mock.assert_awaited_once_with(_SILABS_APPLOADER_BOOT_DELAY)
 
 
 @pytest.mark.asyncio
 async def test_silabs_ota_missing_control_char_raises() -> None:
     """OTAError when the AppLoader OTA control characteristic is absent."""
-    client = _make_bleak_client(["some-other-uuid"])
+    client = _make_bleak_client([_SILABS_OTA_DATA_UUID, "some-other-uuid"])
 
     with (
         patch("opendisplay.ota.asyncio.sleep", new=AsyncMock()),
-        patch("bleak.BleakClient", return_value=client),
+        _patch_connect(client),
+    ):
+        with pytest.raises(OTAError, match="not in Silabs OTA mode"):
+            await perform_silabs_ota(b"\x00" * 10, _make_ble_device())
+
+    # Even on failure the one-shot connection is closed.
+    client.disconnect.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_silabs_ota_missing_data_char_raises() -> None:
+    """OTAError when the OTA data characteristic is absent (control present)."""
+    client = _make_bleak_client([_SILABS_OTA_CONTROL_UUID])
+
+    with (
+        patch("opendisplay.ota.asyncio.sleep", new=AsyncMock()),
+        _patch_connect(client),
     ):
         with pytest.raises(OTAError, match="not in Silabs OTA mode"):
             await perform_silabs_ota(b"\x00" * 10, _make_ble_device())
 
 
 @pytest.mark.asyncio
-async def test_silabs_ota_connection_error_wrapped() -> None:
-    """Non-OTA exceptions from BleakClient are wrapped in OTAError."""
-    client = MagicMock()
-    client.__aenter__ = AsyncMock(side_effect=RuntimeError("connection refused"))
-    client.__aexit__ = AsyncMock(return_value=False)
+async def test_silabs_ota_connect_failure_wrapped() -> None:
+    """A failed connection is wrapped in OTAError with a connect-specific message."""
+    with (
+        patch("opendisplay.ota.asyncio.sleep", new=AsyncMock()),
+        _patch_connect(RuntimeError("connection refused")),
+    ):
+        with pytest.raises(OTAError, match="Could not connect to AppLoader"):
+            await perform_silabs_ota(b"\x00" * 10, _make_ble_device())
+
+
+@pytest.mark.asyncio
+async def test_silabs_ota_transfer_error_wrapped() -> None:
+    """An error mid-transfer is wrapped in OTAError and the connection still closed."""
+    client = _make_bleak_client([_SILABS_OTA_CONTROL_UUID, _SILABS_OTA_DATA_UUID])
+    client.write_gatt_char = AsyncMock(side_effect=RuntimeError("gatt write failed"))
 
     with (
         patch("opendisplay.ota.asyncio.sleep", new=AsyncMock()),
-        patch("bleak.BleakClient", return_value=client),
+        _patch_connect(client),
     ):
         with pytest.raises(OTAError, match="Silabs OTA failed"):
             await perform_silabs_ota(b"\x00" * 10, _make_ble_device())
+
+    client.disconnect.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -129,7 +177,7 @@ async def test_silabs_ota_no_progress_callback() -> None:
 
     with (
         patch("opendisplay.ota.asyncio.sleep", new=AsyncMock()),
-        patch("bleak.BleakClient", return_value=client),
+        _patch_connect(client),
     ):
         await perform_silabs_ota(b"\x00" * 10, _make_ble_device(), on_progress=None)
 
@@ -142,7 +190,7 @@ async def test_silabs_ota_log_callback() -> None:
 
     with (
         patch("opendisplay.ota.asyncio.sleep", new=AsyncMock()),
-        patch("bleak.BleakClient", return_value=client),
+        _patch_connect(client),
     ):
         await perform_silabs_ota(b"\x00" * 10, _make_ble_device(), on_log=logs.append)
 

--- a/tests/unit/test_ota.py
+++ b/tests/unit/test_ota.py
@@ -12,6 +12,7 @@ from opendisplay.ota import (
     _SILABS_OTA_CHUNK_SIZE,
     _SILABS_OTA_CONTROL_UUID,
     _SILABS_OTA_DATA_UUID,
+    _SILABS_OTA_WINDOW,
     find_nrf_dfu_device,
     perform_silabs_ota,
 )
@@ -84,8 +85,10 @@ async def test_silabs_ota_happy_path() -> None:
     total_sent = sum(len(c.args[1]) for c in data_calls)
     assert total_sent == len(gbl)
     assert all(len(c.args[1]) <= _SILABS_OTA_CHUNK_SIZE for c in data_calls)
-    # Write-with-response paces the stream and provides backpressure over BT proxies.
-    assert all(c.kwargs["response"] is True for c in data_calls)
+    # Windowed flow control: earlier chunks stream write-without-response; the
+    # final chunk is synced (response=True) so data is acked before finalize.
+    assert data_calls[0].kwargs["response"] is False
+    assert data_calls[-1].kwargs["response"] is True
 
     # Last call: OTA finalize (0x03)
     assert calls[-1].args[0] == _SILABS_OTA_CONTROL_UUID
@@ -98,6 +101,27 @@ async def test_silabs_ota_happy_path() -> None:
 
     # The single connection is always closed.
     client.disconnect.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_silabs_ota_windowed_flow_control() -> None:
+    """Data chunks sync (response=True) every WINDOW chunks and on the last chunk."""
+    n_chunks = _SILABS_OTA_WINDOW * 2 + 3  # spans 2 full windows + a partial tail
+    gbl = b"\x00" * (_SILABS_OTA_CHUNK_SIZE * n_chunks)
+    client = _make_bleak_client([_SILABS_OTA_CONTROL_UUID, _SILABS_OTA_DATA_UUID])
+
+    with (
+        patch("opendisplay.ota.asyncio.sleep", new=AsyncMock()),
+        _patch_connect(client),
+    ):
+        await perform_silabs_ota(gbl, _make_ble_device())
+
+    data_calls = [c for c in client.write_gatt_char.call_args_list if c.args[0] == _SILABS_OTA_DATA_UUID]
+    assert len(data_calls) == n_chunks
+    # 1-based chunk indices that were synced.
+    synced = [i for i, c in enumerate(data_calls, start=1) if c.kwargs["response"] is True]
+    expected = sorted(set(range(_SILABS_OTA_WINDOW, n_chunks + 1, _SILABS_OTA_WINDOW)) | {n_chunks})
+    assert synced == expected
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_ota.py
+++ b/tests/unit/test_ota.py
@@ -128,3 +128,127 @@ async def test_silabs_ota_missing_dependency_raises() -> None:
     with patch.dict("sys.modules", {"silabs_ble_ota": None}):
         with pytest.raises(OTAError, match="silabs-ble-ota is required"):
             await perform_silabs_ota(b"", _make_ble_device())
+
+
+# ---------------------------------------------------------------------------
+# perform_silabs_ota — delegates to silabs-ble-ota, maps its error
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_silabs_ota_delegates_and_maps_errors() -> None:
+    """The wrapper forwards (incl. fast=) to silabs_ble_ota and maps SilabsOTAError → OTAError."""
+    import types
+
+    from opendisplay.ota import perform_silabs_ota
+
+    fake = types.ModuleType("silabs_ble_ota")
+
+    class _SilabsOTAError(Exception):
+        pass
+
+    seen: dict[str, object] = {}
+
+    async def _flash(gbl, dev, on_progress, on_log, *, fast):  # noqa: ANN001
+        seen["call"] = (gbl, dev, fast)
+
+    fake.SilabsOTAError = _SilabsOTAError  # type: ignore[attr-defined]
+    fake.perform_silabs_ota = _flash  # type: ignore[attr-defined]
+
+    dev = _make_ble_device()
+    with patch.dict("sys.modules", {"silabs_ble_ota": fake}):
+        await perform_silabs_ota(b"GBL", dev, fast=True)
+        assert seen["call"] == (b"GBL", dev, True)
+
+        async def _flash_fail(*_a, **_k):
+            raise _SilabsOTAError("boom")
+
+        fake.perform_silabs_ota = _flash_fail  # type: ignore[attr-defined]
+        with pytest.raises(OTAError, match="boom"):
+            await perform_silabs_ota(b"", _make_ble_device())
+
+
+# ---------------------------------------------------------------------------
+# perform_nrf_dfu — connect (via establish_connection) + LegacyDFU orchestration
+# ---------------------------------------------------------------------------
+
+
+def _make_dfu_client(service_uuid: str = "00001530-1212-efde-1523-785feabcd123") -> AsyncMock:
+    """A connected DFU client exposing the Legacy DFU service UUID."""
+    client = AsyncMock()
+    svc = MagicMock()
+    svc.uuid = service_uuid
+    client.services = [svc]
+    return client
+
+
+@pytest.mark.asyncio
+async def test_perform_nrf_dfu_happy_path() -> None:
+    """Connects, runs the full LegacyDFU sequence, and disconnects."""
+    from opendisplay.ota import perform_nrf_dfu
+
+    client = _make_dfu_client()
+    dfu = AsyncMock()
+    dfu.read_version = AsyncMock(return_value=(0, 8))
+    zip_info = MagicMock(firmware=b"\x00" * 100, init_packet=b"\x01\x02")
+
+    with (
+        patch("bleak_retry_connector.establish_connection", new=AsyncMock(return_value=client)),
+        patch("nrf_ota.dfu.LegacyDFU", return_value=dfu),
+        patch("nrf_ota._zip._parse_zip_bytes", return_value=zip_info),
+    ):
+        await perform_nrf_dfu(b"zip", _make_ble_device())
+
+    dfu.start.assert_awaited_once()
+    dfu.start_dfu.assert_awaited_once()
+    dfu.init_dfu.assert_awaited_once()
+    dfu.send_firmware.assert_awaited_once()
+    dfu.activate_and_reset.assert_awaited_once()
+    client.disconnect.assert_awaited()
+    # default (not fast) paces the firmware stream
+    assert dfu.send_firmware.await_args.kwargs["inter_packet_delay"] > 0
+
+
+@pytest.mark.asyncio
+async def test_perform_nrf_dfu_fast_sends_unpaced() -> None:
+    """fast=True streams with no inter-packet delay."""
+    from opendisplay.ota import perform_nrf_dfu
+
+    client = _make_dfu_client()
+    dfu = AsyncMock()
+    dfu.read_version = AsyncMock(return_value=(0, 8))
+    with (
+        patch("bleak_retry_connector.establish_connection", new=AsyncMock(return_value=client)),
+        patch("nrf_ota.dfu.LegacyDFU", return_value=dfu),
+        patch("nrf_ota._zip._parse_zip_bytes", return_value=MagicMock(firmware=b"x" * 40, init_packet=b"i")),
+    ):
+        await perform_nrf_dfu(b"zip", _make_ble_device(), fast=True)
+    assert dfu.send_firmware.await_args.kwargs["inter_packet_delay"] == 0.0
+
+
+@pytest.mark.asyncio
+async def test_perform_nrf_dfu_not_in_dfu_mode_raises() -> None:
+    """A device without the Legacy DFU service raises OTAError and still disconnects."""
+    from opendisplay.ota import perform_nrf_dfu
+
+    client = _make_dfu_client(service_uuid="0000abcd-0000-1000-8000-00805f9b34fb")
+    with (
+        patch("bleak_retry_connector.establish_connection", new=AsyncMock(return_value=client)),
+        patch("nrf_ota._zip._parse_zip_bytes", return_value=MagicMock(firmware=b"x", init_packet=b"i")),
+    ):
+        with pytest.raises(OTAError, match="not in Nordic Legacy DFU mode"):
+            await perform_nrf_dfu(b"zip", _make_ble_device())
+    client.disconnect.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_perform_nrf_dfu_connect_failure_raises() -> None:
+    """A failed connection is wrapped in OTAError."""
+    from opendisplay.ota import perform_nrf_dfu
+
+    with (
+        patch("bleak_retry_connector.establish_connection", new=AsyncMock(side_effect=RuntimeError("nope"))),
+        patch("nrf_ota._zip._parse_zip_bytes", return_value=MagicMock(firmware=b"x", init_packet=b"i")),
+    ):
+        with pytest.raises(OTAError, match="Could not connect to nRF DFU bootloader"):
+            await perform_nrf_dfu(b"zip", _make_ble_device())

--- a/tests/unit/test_ota.py
+++ b/tests/unit/test_ota.py
@@ -1,4 +1,10 @@
-"""Tests for OTA firmware update utilities."""
+"""Tests for OTA firmware update utilities.
+
+The Silabs and nRF OTA *protocols* live in their own libraries
+(``silabs-ble-ota`` / ``nrf-ota``) and are tested there. Here we only cover the
+py-opendisplay-side glue: ``find_nrf_dfu_device`` and the lazy-import guards in
+the ``perform_*`` wrappers.
+"""
 
 from __future__ import annotations
 
@@ -7,242 +13,13 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from opendisplay.exceptions import OTAError
-from opendisplay.ota import (
-    _SILABS_APPLOADER_BOOT_DELAY,
-    _SILABS_OTA_CHUNK_SIZE,
-    _SILABS_OTA_CONTROL_UUID,
-    _SILABS_OTA_DATA_UUID,
-    _SILABS_OTA_WINDOW,
-    find_nrf_dfu_device,
-    perform_silabs_ota,
-)
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-
-def _make_bleak_client(char_uuids: list[str]) -> MagicMock:
-    """Return a mock client (as returned by establish_connection) whose services
-    expose the given char UUIDs. write_gatt_char/disconnect are AsyncMocks."""
-    char_mocks = [MagicMock(uuid=uuid) for uuid in char_uuids]
-    svc = MagicMock()
-    svc.characteristics = char_mocks
-    client = AsyncMock()
-    client.services = [svc]
-    return client
-
-
-def _patch_connect(client_or_exc) -> object:
-    """Patch establish_connection to return a client (or raise an exception)."""
-    if isinstance(client_or_exc, BaseException):
-        return patch(
-            "bleak_retry_connector.establish_connection",
-            new=AsyncMock(side_effect=client_or_exc),
-        )
-    return patch(
-        "bleak_retry_connector.establish_connection",
-        new=AsyncMock(return_value=client_or_exc),
-    )
+from opendisplay.ota import find_nrf_dfu_device
 
 
 def _make_ble_device(address: str = "AA:BB:CC:DD:EE:FF") -> MagicMock:
     dev = MagicMock()
     dev.address = address
     return dev
-
-
-# ---------------------------------------------------------------------------
-# perform_silabs_ota
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.asyncio
-async def test_silabs_ota_happy_path() -> None:
-    """Full OTA transfer: start write, all data chunks, finalize write, disconnect."""
-    gbl = bytes(range(256)) * 2  # 512 bytes → 3 chunks of 244/244/24
-    client = _make_bleak_client([_SILABS_OTA_CONTROL_UUID, _SILABS_OTA_DATA_UUID])
-    progress: list[float] = []
-    connect = AsyncMock(return_value=client)
-
-    with (
-        patch("opendisplay.ota.asyncio.sleep", new=AsyncMock()),
-        patch("bleak_retry_connector.establish_connection", new=connect),
-    ):
-        await perform_silabs_ota(gbl, _make_ble_device(), on_progress=progress.append)
-
-    # Fresh GATT discovery, not the cached app-firmware service table.
-    assert connect.await_args.kwargs["use_services_cache"] is False
-
-    calls = client.write_gatt_char.call_args_list
-    # First call: OTA start (0x00)
-    assert calls[0].args[0] == _SILABS_OTA_CONTROL_UUID
-    assert calls[0].args[1] == bytearray([0x00])
-    assert calls[0].kwargs["response"] is True
-
-    # Middle calls: data chunks
-    data_calls = [c for c in calls if c.args[0] == _SILABS_OTA_DATA_UUID]
-    total_sent = sum(len(c.args[1]) for c in data_calls)
-    assert total_sent == len(gbl)
-    assert all(len(c.args[1]) <= _SILABS_OTA_CHUNK_SIZE for c in data_calls)
-    # The final chunk is always synced (response=True) so data is acked before
-    # finalize. (With _SILABS_OTA_WINDOW=1 every chunk is synced.)
-    assert data_calls[-1].kwargs["response"] is True
-
-    # Last call: OTA finalize (0x03)
-    assert calls[-1].args[0] == _SILABS_OTA_CONTROL_UUID
-    assert calls[-1].args[1] == bytearray([0x03])
-    assert calls[-1].kwargs["response"] is True
-
-    # Progress goes from > 0 to 100
-    assert progress[0] > 0
-    assert progress[-1] == pytest.approx(100.0)
-
-    # The single connection is always closed.
-    client.disconnect.assert_awaited_once()
-
-
-@pytest.mark.asyncio
-async def test_silabs_ota_windowed_flow_control() -> None:
-    """Data chunks sync (response=True) every WINDOW chunks and on the last chunk."""
-    n_chunks = _SILABS_OTA_WINDOW * 2 + 3  # spans 2 full windows + a partial tail
-    gbl = b"\x00" * (_SILABS_OTA_CHUNK_SIZE * n_chunks)
-    client = _make_bleak_client([_SILABS_OTA_CONTROL_UUID, _SILABS_OTA_DATA_UUID])
-
-    with (
-        patch("opendisplay.ota.asyncio.sleep", new=AsyncMock()),
-        _patch_connect(client),
-    ):
-        await perform_silabs_ota(gbl, _make_ble_device())
-
-    data_calls = [c for c in client.write_gatt_char.call_args_list if c.args[0] == _SILABS_OTA_DATA_UUID]
-    assert len(data_calls) == n_chunks
-    # 1-based chunk indices that were synced.
-    synced = [i for i, c in enumerate(data_calls, start=1) if c.kwargs["response"] is True]
-    expected = sorted(set(range(_SILABS_OTA_WINDOW, n_chunks + 1, _SILABS_OTA_WINDOW)) | {n_chunks})
-    assert synced == expected
-
-
-@pytest.mark.asyncio
-async def test_silabs_ota_retries_on_congestion() -> None:
-    """A 'Congested' proxy error on a data write is retried, not fatal."""
-    client = _make_bleak_client([_SILABS_OTA_CONTROL_UUID, _SILABS_OTA_DATA_UUID])
-    fails = {"n": 0}
-
-    async def write(uuid, data, response=False):  # noqa: ARG001
-        if uuid == _SILABS_OTA_DATA_UUID and fails["n"] < 2:
-            fails["n"] += 1
-            raise RuntimeError("Bluetooth GATT Error ... description=Congested")
-
-    client.write_gatt_char = AsyncMock(side_effect=write)
-
-    with (
-        patch("opendisplay.ota.asyncio.sleep", new=AsyncMock()),
-        _patch_connect(client),
-    ):
-        await perform_silabs_ota(b"\x00" * (_SILABS_OTA_CHUNK_SIZE * 2), _make_ble_device())
-
-    # The first data chunk was resent twice (Congested) then succeeded.
-    assert fails["n"] == 2
-
-
-@pytest.mark.asyncio
-async def test_silabs_ota_waits_for_apploader_boot() -> None:
-    """perform_silabs_ota waits for the AppLoader to boot before connecting."""
-    sleep_mock = AsyncMock()
-    client = _make_bleak_client([_SILABS_OTA_CONTROL_UUID, _SILABS_OTA_DATA_UUID])
-
-    with (
-        patch("opendisplay.ota.asyncio.sleep", new=sleep_mock),
-        _patch_connect(client),
-    ):
-        await perform_silabs_ota(b"\x00" * 10, _make_ble_device())
-
-    sleep_mock.assert_awaited_once_with(_SILABS_APPLOADER_BOOT_DELAY)
-
-
-@pytest.mark.asyncio
-async def test_silabs_ota_missing_control_char_raises() -> None:
-    """OTAError when the AppLoader OTA control characteristic is absent."""
-    client = _make_bleak_client([_SILABS_OTA_DATA_UUID, "some-other-uuid"])
-
-    with (
-        patch("opendisplay.ota.asyncio.sleep", new=AsyncMock()),
-        _patch_connect(client),
-    ):
-        with pytest.raises(OTAError, match="not in Silabs OTA mode"):
-            await perform_silabs_ota(b"\x00" * 10, _make_ble_device())
-
-    # Even on failure the one-shot connection is closed.
-    client.disconnect.assert_awaited_once()
-
-
-@pytest.mark.asyncio
-async def test_silabs_ota_missing_data_char_raises() -> None:
-    """OTAError when the OTA data characteristic is absent (control present)."""
-    client = _make_bleak_client([_SILABS_OTA_CONTROL_UUID])
-
-    with (
-        patch("opendisplay.ota.asyncio.sleep", new=AsyncMock()),
-        _patch_connect(client),
-    ):
-        with pytest.raises(OTAError, match="not in Silabs OTA mode"):
-            await perform_silabs_ota(b"\x00" * 10, _make_ble_device())
-
-
-@pytest.mark.asyncio
-async def test_silabs_ota_connect_failure_wrapped() -> None:
-    """A failed connection is wrapped in OTAError with a connect-specific message."""
-    with (
-        patch("opendisplay.ota.asyncio.sleep", new=AsyncMock()),
-        _patch_connect(RuntimeError("connection refused")),
-    ):
-        with pytest.raises(OTAError, match="Could not connect to AppLoader"):
-            await perform_silabs_ota(b"\x00" * 10, _make_ble_device())
-
-
-@pytest.mark.asyncio
-async def test_silabs_ota_transfer_error_wrapped() -> None:
-    """An error mid-transfer is wrapped in OTAError and the connection still closed."""
-    client = _make_bleak_client([_SILABS_OTA_CONTROL_UUID, _SILABS_OTA_DATA_UUID])
-    client.write_gatt_char = AsyncMock(side_effect=RuntimeError("gatt write failed"))
-
-    with (
-        patch("opendisplay.ota.asyncio.sleep", new=AsyncMock()),
-        _patch_connect(client),
-    ):
-        with pytest.raises(OTAError, match="Silabs OTA failed"):
-            await perform_silabs_ota(b"\x00" * 10, _make_ble_device())
-
-    client.disconnect.assert_awaited_once()
-
-
-@pytest.mark.asyncio
-async def test_silabs_ota_no_progress_callback() -> None:
-    """perform_silabs_ota works without an on_progress callback."""
-    client = _make_bleak_client([_SILABS_OTA_CONTROL_UUID, _SILABS_OTA_DATA_UUID])
-
-    with (
-        patch("opendisplay.ota.asyncio.sleep", new=AsyncMock()),
-        _patch_connect(client),
-    ):
-        await perform_silabs_ota(b"\x00" * 10, _make_ble_device(), on_progress=None)
-
-
-@pytest.mark.asyncio
-async def test_silabs_ota_log_callback() -> None:
-    """on_log receives status messages during the transfer."""
-    client = _make_bleak_client([_SILABS_OTA_CONTROL_UUID, _SILABS_OTA_DATA_UUID])
-    logs: list[str] = []
-
-    with (
-        patch("opendisplay.ota.asyncio.sleep", new=AsyncMock()),
-        _patch_connect(client),
-    ):
-        await perform_silabs_ota(b"\x00" * 10, _make_ble_device(), on_log=logs.append)
-
-    assert any("AppLoader" in msg for msg in logs)
-    assert any("complete" in msg.lower() for msg in logs)
 
 
 # ---------------------------------------------------------------------------
@@ -323,7 +100,7 @@ async def test_find_nrf_dfu_device_mac_plus1_wraps_ff() -> None:
 
 
 # ---------------------------------------------------------------------------
-# perform_nrf_dfu — import guard
+# perform_* wrappers — optional-dependency import guards
 # ---------------------------------------------------------------------------
 
 
@@ -341,3 +118,13 @@ async def test_nrf_dfu_missing_dependency_raises() -> None:
     with patch.dict("sys.modules", blocked):
         with pytest.raises(OTAError, match="nrf-ota is required"):
             await perform_nrf_dfu(b"", _make_ble_device())
+
+
+@pytest.mark.asyncio
+async def test_silabs_ota_missing_dependency_raises() -> None:
+    """OTAError with install hint when silabs-ble-ota is not installed."""
+    from opendisplay.ota import perform_silabs_ota
+
+    with patch.dict("sys.modules", {"silabs_ble_ota": None}):
+        with pytest.raises(OTAError, match="silabs-ble-ota is required"):
+            await perform_silabs_ota(b"", _make_ble_device())

--- a/tests/unit/test_ota.py
+++ b/tests/unit/test_ota.py
@@ -85,9 +85,8 @@ async def test_silabs_ota_happy_path() -> None:
     total_sent = sum(len(c.args[1]) for c in data_calls)
     assert total_sent == len(gbl)
     assert all(len(c.args[1]) <= _SILABS_OTA_CHUNK_SIZE for c in data_calls)
-    # Windowed flow control: earlier chunks stream write-without-response; the
-    # final chunk is synced (response=True) so data is acked before finalize.
-    assert data_calls[0].kwargs["response"] is False
+    # The final chunk is always synced (response=True) so data is acked before
+    # finalize. (With _SILABS_OTA_WINDOW=1 every chunk is synced.)
     assert data_calls[-1].kwargs["response"] is True
 
     # Last call: OTA finalize (0x03)

--- a/uv.lock
+++ b/uv.lock
@@ -655,14 +655,14 @@ wheels = [
 
 [[package]]
 name = "nrf-ota"
-version = "0.3.0"
+version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "bleak" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/64/c5/ecdb03b45f0d64d43894898120a775a9bd77ba6d8fc56cd1cbb5a142e7d3/nrf_ota-0.3.0.tar.gz", hash = "sha256:d0010efbb193057cbf0921cb748056b482c16445638a2f6fd9560d96ec9b2dea", size = 76145, upload-time = "2026-02-23T23:12:29.422Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/98/66/25b62e03883c589f13fe3c3793929e08178202f3d2d8e581a22c66e5afff/nrf_ota-0.4.0.tar.gz", hash = "sha256:4e645a1db9df600020ec4127e0dbfde79b684b431f7ccd71dce270f5a4f3f6a9", size = 84979, upload-time = "2026-06-02T18:04:59.85Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/dc/da/5141bc9288a46a133e7644e188dc2c667b2e23f90a59003b6ca043c1d6a4/nrf_ota-0.3.0-py3-none-any.whl", hash = "sha256:f4eaf7a3f05974c4430b640782eaae98d0d36bdef60e118db00d70309722de01", size = 22046, upload-time = "2026-02-23T23:12:28.057Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/e4/ae471c72f2b3dc8e219002478bf90434e6f4e8ebb23d0e4513b1f7fbff99/nrf_ota-0.4.0-py3-none-any.whl", hash = "sha256:073613c7a1d58b2bf7866b13d6ccf2c435128f7e585dbc18d7d44f9939cd4972", size = 23216, upload-time = "2026-06-02T18:04:58.495Z" },
 ]
 
 [[package]]
@@ -937,7 +937,7 @@ requires-dist = [
     { name = "cryptography", specifier = ">=41.0.0" },
     { name = "epaper-dithering", specifier = "==5.0.6" },
     { name = "hypothesis", marker = "extra == 'test'", specifier = ">=6.148.8" },
-    { name = "nrf-ota", marker = "extra == 'nrf-ota'", specifier = ">=0.3.0" },
+    { name = "nrf-ota", marker = "extra == 'nrf-ota'", specifier = ">=0.4.0" },
     { name = "numpy", specifier = ">=1.24.0,!=2.4.0" },
     { name = "pillow", specifier = ">=10.0.0" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=9.0.2" },

--- a/uv.lock
+++ b/uv.lock
@@ -911,6 +911,9 @@ cli = [
 nrf-ota = [
     { name = "nrf-ota" },
 ]
+silabs-ota = [
+    { name = "silabs-ble-ota" },
+]
 test = [
     { name = "hypothesis" },
     { name = "pytest" },
@@ -942,8 +945,9 @@ requires-dist = [
     { name = "pytest-cov", marker = "extra == 'test'", specifier = ">=7.0.0" },
     { name = "pytest-xdist", marker = "extra == 'test'", specifier = ">=3.8.0" },
     { name = "rich", marker = "extra == 'cli'", specifier = ">=13.0.0" },
+    { name = "silabs-ble-ota", marker = "extra == 'silabs-ota'", specifier = ">=0.1.0" },
 ]
-provides-extras = ["cli", "nrf-ota", "test"]
+provides-extras = ["cli", "nrf-ota", "silabs-ota", "test"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1148,6 +1152,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ea/f9/0ae446942c846b8266059ad8a30702a35afae55f5cdc54c5adf8d7afdc27/ruff-0.15.12-py3-none-win32.whl", hash = "sha256:d0185894e038d7043ba8fd6aee7499ece6462dc0ea9f1e260c7451807c714c20", size = 10657277, upload-time = "2026-04-24T18:17:18.591Z" },
     { url = "https://files.pythonhosted.org/packages/33/f1/9614e03e1cdcbf9437570b5400ced8a720b5db22b28d8e0f1bda429f660d/ruff-0.15.12-py3-none-win_amd64.whl", hash = "sha256:c87a162d61ab3adca47c03f7f717c68672edec7d1b5499e652331780fe74950d", size = 11837758, upload-time = "2026-04-24T18:17:00.113Z" },
     { url = "https://files.pythonhosted.org/packages/c0/98/6beb4b351e472e5f4c4613f7c35a5290b8be2497e183825310c4c3a3984b/ruff-0.15.12-py3-none-win_arm64.whl", hash = "sha256:a538f7a82d061cee7be55542aca1d86d1393d55d81d4fcc314370f4340930d4f", size = 11120821, upload-time = "2026-04-24T18:16:57.979Z" },
+]
+
+[[package]]
+name = "silabs-ble-ota"
+version = "0.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "bleak" },
+    { name = "bleak-retry-connector" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/40/d3/93c3fd8d646ba4550d1d4a95d8c4014836c05bd6e67b4d8203f2a3186c5b/silabs_ble_ota-0.1.0.tar.gz", hash = "sha256:4559504886d3cc7fd53b2ec200a86e6dadeda944ced727ce5786519817ba7e92", size = 69154, upload-time = "2026-06-01T19:16:22.11Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e4/b6/a57bae5ec8772a7ea977507aef788b0e1c162728ec58dfd7f34ae2a8912f/silabs_ble_ota-0.1.0-py3-none-any.whl", hash = "sha256:ba1add7e96dda03ffb50c1737e49fad09db764c78c2a6f84738ea40d856c7c58", size = 12101, upload-time = "2026-06-01T19:16:20.792Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adds proxy-safe BLE OTA firmware update dispatch.

- Split Silabs AppLoader OTA into the standalone `silabs-ble-ota` library; `perform_silabs_ota` is now a thin wrapper (optional `[silabs-ota]` extra).
- `perform_nrf_dfu` connects via `bleak-retry-connector` (`establish_connection`) so nRF Legacy DFU works on a direct link; adds inter-packet pacing and a `fast` flag (requires `nrf-ota>=0.4.0`, the `[nrf-ota]` extra).
- Proxy robustness: connect-layer stale-GATT-cache clear+retry, `OpenDisplayDevice.clear_gatt_cache()`, `trigger_dfu_bootloader()`.
- Both `perform_*` expose a proxy-safe `fast` flag.

---
**Squash-merge** — this branch has iterative/experimental commits (Silabs window tuning, nRF pacing experiments + a revert). Use the title above as the squash commit subject so release-please produces a clean minor release (→ 7.4.0).