### PR TITLE
feat: sync Solum/OpenDisplay board types with config tool

### DIFF
--- a/src/opendisplay/models/enums.py
+++ b/src/opendisplay/models/enums.py
@@ -67,14 +67,30 @@ class WaveshareBoardType(IntEnum):
 
 
 class SolumBoardType(IntEnum):
-    """Solum board types."""
+    """Solum board types.
 
+    Mirrors the ``board_type`` ``conditional_enum`` for ``manufacturer_id: 3``
+    in the Web config tool's ``config.yaml`` (source of truth).
+    """
+
+    M3_NRF_LITE = 0
+    M3_NRF = 1
+    M3_SILABS = 2
+    M3_SILABS_CORE = 3
+    M3_SILABS_PRO = 4
+    M3_SILABS_LITE = 5
+    M3_SILABS_PEGHOOK = 6
+
+    # Backwards-compat alias for the original single Solum entry (board_type 0).
     M3 = 0
 
 
 class OpenDisplayBoardType(IntEnum):
     """OpenDisplay board types."""
 
+    OD01 = 0
+
+    # Backwards-compat alias for the original name of board_type 0.
     DEFAULT = 0
 
 
@@ -151,11 +167,17 @@ _BOARD_TYPE_NAMES_WAVESHARE: Final[dict[WaveshareBoardType, str]] = {
 }
 
 _BOARD_TYPE_NAMES_SOLUM: Final[dict[SolumBoardType, str]] = {
-    SolumBoardType.M3: "M3",
+    SolumBoardType.M3_NRF_LITE: "M3 NRF Lite",
+    SolumBoardType.M3_NRF: "M3 NRF",
+    SolumBoardType.M3_SILABS: "M3 Silabs",
+    SolumBoardType.M3_SILABS_CORE: "M3 Silabs Core",
+    SolumBoardType.M3_SILABS_PRO: "M3 Silabs Pro",
+    SolumBoardType.M3_SILABS_LITE: "M3 Silabs Lite",
+    SolumBoardType.M3_SILABS_PEGHOOK: "M3 Silabs Peghook",
 }
 
 _BOARD_TYPE_NAMES_OPENDISPLAY: Final[dict[OpenDisplayBoardType, str]] = {
-    OpenDisplayBoardType.DEFAULT: "Default",
+    OpenDisplayBoardType.OD01: "OD01",
 }
 
 

--- a/tests/unit/test_models_new_packets.py
+++ b/tests/unit/test_models_new_packets.py
@@ -75,8 +75,9 @@ class TestNewEnumValues:
         assert get_manufacturer_name(BoardManufacturer.OPENDISPLAY) == "OpenDisplay"
 
     def test_opendisplay_board_type(self):
-        assert OpenDisplayBoardType.DEFAULT == 0
-        assert get_board_type_name(BoardManufacturer.OPENDISPLAY, 0) == "Default"
+        assert OpenDisplayBoardType.OD01 == 0
+        assert OpenDisplayBoardType.DEFAULT == 0  # backwards-compat alias
+        assert get_board_type_name(BoardManufacturer.OPENDISPLAY, 0) == "OD01"
         assert get_board_type_name(BoardManufacturer.OPENDISPLAY, 99) is None
 
     def test_seeed_reterminal_e1003(self):

--- a/tests/unit/test_module_enums.py
+++ b/tests/unit/test_module_enums.py
@@ -9,6 +9,7 @@ from opendisplay.models.enums import (
     RefreshMode,
     Rotation,
     SeeedBoardType,
+    SolumBoardType,
     WaveshareBoardType,
     get_board_type_name,
     get_manufacturer_name,
@@ -99,6 +100,17 @@ class TestBoardTypeEnums:
         """Test Waveshare board type values."""
         assert WaveshareBoardType.ESP32_S3_PHOTOPAINTER == 0
 
+    def test_solum_board_type_values(self):
+        """Test Solum board type values (mirror config.yaml board_type enum)."""
+        assert SolumBoardType.M3_NRF_LITE == 0
+        assert SolumBoardType.M3_NRF == 1
+        assert SolumBoardType.M3_SILABS == 2
+        assert SolumBoardType.M3_SILABS_CORE == 3
+        assert SolumBoardType.M3_SILABS_PRO == 4
+        assert SolumBoardType.M3_SILABS_LITE == 5
+        assert SolumBoardType.M3_SILABS_PEGHOOK == 6
+        assert SolumBoardType.M3 == 0  # backwards-compat alias
+
     def test_board_type_name_helpers(self):
         """Test board type and manufacturer name helpers."""
         assert get_manufacturer_name(BoardManufacturer.DIY) == "DIY"
@@ -107,6 +119,12 @@ class TestBoardTypeEnums:
         assert get_board_type_name(BoardManufacturer.DIY, 0) == "Custom"
         assert get_board_type_name(BoardManufacturer.SEEED, 1) == "EN04"
         assert get_board_type_name(BoardManufacturer.WAVESHARE, 0) == "PhotoPainter"
+        # Solum: the full M3 variant set (previously only board_type 0 was known,
+        # so real devices like board_type 4 surfaced as the raw int in HA).
+        assert get_board_type_name(BoardManufacturer.SOLUM, 0) == "M3 NRF Lite"
+        assert get_board_type_name(BoardManufacturer.SOLUM, 4) == "M3 Silabs Pro"
+        assert get_board_type_name(BoardManufacturer.SOLUM, 6) == "M3 Silabs Peghook"
+        assert get_board_type_name(BoardManufacturer.OPENDISPLAY, 0) == "OD01"
         assert get_board_type_name(BoardManufacturer.SEEED, 99) is None
         assert get_board_type_name(99, 0) is None
 


### PR DESCRIPTION
Solum SolumBoardType only knew M3=0, so devices reporting board_type 4 surfaced as raw '4 rev. 1' in Home Assistant. Mirror the seven M3 variants (and OpenDisplay OD01) from the Web config tool's config.yaml so HA shows friendly names like 'M3 Silabs Pro'.