### PR TITLE
Add Inkplate 6COLOR (7-color ACeP) support

### DIFF
--- a/src/opendisplay/display_palettes.py
+++ b/src/opendisplay/display_palettes.py
@@ -2,6 +2,7 @@
 
 from epaper_dithering import (
     BWRY_3_97,
+    INKPLATE_6COLOR,
     MONO_4_26,
     SOLUM_BWR,
     SPECTRA_7_3_6COLOR,
@@ -53,6 +54,8 @@ DISPLAY_PALETTE_MAP: dict[tuple[int, ColorScheme], ColorPalette] = {
     (33, ColorScheme.BWR): SOLUM_BWR,
     # 3.97" BWRY (ep397yr_800x480)
     (55, ColorScheme.BWRY): BWRY_3_97,
+    # Inkplate 6COLOR 7-color ACeP (EP585C_600x448 / panel_ic_type 0x0043)
+    (0x0043, ColorScheme.BWGBRYO): INKPLATE_6COLOR,
     # Add more as color calibration becomes available:
     # (?, ColorScheme.BWRY): BWRY_4_2,  # 4.2" BWRY
     # (?, ColorScheme.BWR): HANSHOW_BWR,

--- a/src/opendisplay/display_palettes.py
+++ b/src/opendisplay/display_palettes.py
@@ -1,8 +1,10 @@
 """Automatic measured palette selection and panel capability data for e-paper displays."""
 
+from typing import cast
+
+import epaper_dithering as _epaper_dithering
 from epaper_dithering import (
     BWRY_3_97,
-    INKPLATE_6COLOR,
     MONO_4_26,
     SOLUM_BWR,
     SPECTRA_7_3_6COLOR,
@@ -10,6 +12,7 @@ from epaper_dithering import (
     ColorScheme,
 )
 
+INKPLATE_6COLOR = cast(ColorPalette | None, getattr(_epaper_dithering, "INKPLATE_6COLOR", None))
 # Panel IDs that support 4-gray mode (from firmware mapEpd)
 PANELS_4GRAY: frozenset[int] = frozenset(
     {
@@ -54,13 +57,16 @@ DISPLAY_PALETTE_MAP: dict[tuple[int, ColorScheme], ColorPalette] = {
     (33, ColorScheme.BWR): SOLUM_BWR,
     # 3.97" BWRY (ep397yr_800x480)
     (55, ColorScheme.BWRY): BWRY_3_97,
-    # Inkplate 6COLOR 7-color ACeP (EP585C_600x448 / panel_ic_type 0x0043)
-    (0x0043, ColorScheme.BWGBRYO): INKPLATE_6COLOR,
     # Add more as color calibration becomes available:
     # (?, ColorScheme.BWRY): BWRY_4_2,  # 4.2" BWRY
     # (?, ColorScheme.BWR): HANSHOW_BWR,
     # (?, ColorScheme.BWY): HANSHOW_BWY,
 }
+
+_BWGBRYO = cast(ColorScheme | None, getattr(ColorScheme, "BWGBRYO", None))
+if _BWGBRYO is not None and INKPLATE_6COLOR is not None:
+    # Inkplate 6COLOR 7-color ACeP (EP585C_600x448 / panel_ic_type 0x0043)
+    DISPLAY_PALETTE_MAP[(0x0043, _BWGBRYO)] = INKPLATE_6COLOR
 
 
 def get_palette_for_display(

--- a/src/opendisplay/encoding/images.py
+++ b/src/opendisplay/encoding/images.py
@@ -87,6 +87,10 @@ def encode_image(
         # 6-color Spectra 6 display uses 4bpp with special firmware values
         # Palette indices 0-5 map to firmware values 0,1,2,3,5,6 (4 is skipped!)
         return encode_4bpp(image, bwgbry_mapping=True)
+    if color_scheme == ColorScheme.BWGBRYO:
+        # 7-color ACeP (Inkplate 6COLOR) uses 4bpp. The BWGBRYO palette is already
+        # ordered to the panel's native nibble codes (0..6), so indices map directly.
+        return encode_4bpp(image)
     if color_scheme == ColorScheme.GRAYSCALE_4:
         return encode_2bpp(image)
     if color_scheme == ColorScheme.GRAYSCALE_16:

--- a/src/opendisplay/encoding/images.py
+++ b/src/opendisplay/encoding/images.py
@@ -87,7 +87,7 @@ def encode_image(
         # 6-color Spectra 6 display uses 4bpp with special firmware values
         # Palette indices 0-5 map to firmware values 0,1,2,3,5,6 (4 is skipped!)
         return encode_4bpp(image, bwgbry_mapping=True)
-    if color_scheme == ColorScheme.BWGBRYO:
+    if color_scheme == getattr(ColorScheme, "BWGBRYO", None):
         # 7-color ACeP (Inkplate 6COLOR) uses 4bpp. The BWGBRYO palette is already
         # ordered to the panel's native nibble codes (0..6), so indices map directly.
         return encode_4bpp(image)


### PR DESCRIPTION
## Summary

Adds support for the **Soldered Inkplate 6COLOR** (600×448, 7-color ACeP, `panel_ic_type 0x0043`):

- `DISPLAY_PALETTE_MAP[(0x0043, ColorScheme.BWGBRYO)] = INKPLATE_6COLOR` in `display_palettes.py`.
- `encode_image`: handle `ColorScheme.BWGBRYO` as 4bpp. The palette is ordered to the panel's native nibbles, so indices map directly (identity), unlike `BWGBRY` which remaps.

## Dependency

Requires the `Bwgbryo` scheme + `INKPLATE_6COLOR` palette from **OpenDisplay/epaper-dithering#43**.

## Testing

**Validated end-to-end on real hardware** via the CLI: provisioned an Inkplate 6COLOR (`panel_ic_type=0x0043`, `color_scheme=8`, 600×448) and `opendisplay upload` rendered a dithered image — full transfer + ACeP refresh, correct geometry. Color fidelity depends on the (currently nominal) palette calibration tracked in #43.

## Related

- Device side: bitbank2/bb_epaper#33 (panel driver), OpenDisplay/Firmware#41 (panel mapping)

🤖 Generated with [Claude Code](https://claude.com/claude-code)