### PR TITLE
parse data_extended (0x2c) identity packet

### DIFF
--- a/src/opendisplay/__init__.py
+++ b/src/opendisplay/__init__.py
@@ -39,6 +39,7 @@ from .models.capabilities import DeviceCapabilities
 from .models.config import (
     BinaryInputs,
     DataBus,
+    DataExtended,
     DisplayConfig,
     FlashConfig,
     GlobalConfig,
@@ -123,6 +124,7 @@ __all__ = [
     "PassiveBuzzer",
     "NfcConfig",
     "FlashConfig",
+    "DataExtended",
     "SecurityConfig",
     "TouchController",
     "WifiConfig",

--- a/src/opendisplay/models/__init__.py
+++ b/src/opendisplay/models/__init__.py
@@ -13,6 +13,7 @@ from .capabilities import DeviceCapabilities
 from .config import (
     BinaryInputs,
     DataBus,
+    DataExtended,
     DisplayConfig,
     FlashConfig,
     GlobalConfig,
@@ -70,6 +71,7 @@ __all__ = [
     "config_from_json",
     "config_to_json",
     "DataBus",
+    "DataExtended",
     "DeviceCapabilities",
     "DisplayConfig",
     "FirmwareVersion",

--- a/src/opendisplay/models/config.py
+++ b/src/opendisplay/models/config.py
@@ -39,6 +39,17 @@ from .enums import (
 )
 
 
+def _encode_c_string(value: str, size: int) -> bytes:
+    """Encode string into fixed-size null-padded C string bytes."""
+    encoded = value.encode("utf-8")
+    return encoded[:size].ljust(size, b"\x00")
+
+
+def _decode_c_string(value: bytes) -> str:
+    """Decode fixed-size C string bytes (truncate at first null byte)."""
+    return value.split(b"\x00", 1)[0].decode("utf-8", errors="replace")
+
+
 @dataclass
 class SystemConfig:
     """System configuration (TLV packet type 0x01).
@@ -624,13 +635,12 @@ class WifiConfig:
     @staticmethod
     def encode_c_string(value: str, size: int) -> bytes:
         """Encode string into fixed-size null-padded C string bytes."""
-        encoded = value.encode("utf-8")
-        return encoded[:size].ljust(size, b"\x00")
+        return _encode_c_string(value, size)
 
     @staticmethod
     def decode_c_string(value: bytes) -> str:
         """Decode fixed-size C string bytes (truncate at first null byte)."""
-        return value.split(b"\x00", 1)[0].decode("utf-8", errors="replace")
+        return _decode_c_string(value)
 
     @property
     def ssid_text(self) -> str:
@@ -1039,6 +1049,137 @@ class FlashConfig:
 
 
 @dataclass
+class DataExtended:
+    """Extended device identity strings (TLV packet type 0x2c, single instance).
+
+    Each field is a fixed 32-byte null-terminated UTF-8 string buffer,
+    zero-padded. Empty buffers decode to "".
+
+    Size: 288 bytes (9 x 32-byte string buffers)
+    """
+
+    manufacturer_name: bytes = bytes(32)
+    model_name: bytes = bytes(32)
+    serial_number: bytes = bytes(32)
+    friendly_name: bytes = bytes(32)
+    device_location: bytes = bytes(32)
+    device_id: bytes = bytes(32)
+    custom_string_1: bytes = bytes(32)
+    custom_string_2: bytes = bytes(32)
+    custom_string_3: bytes = bytes(32)
+
+    SIZE: ClassVar[int] = 288
+    FIELD_SIZE: ClassVar[int] = 32
+
+    @property
+    def manufacturer_name_text(self) -> str:
+        """Get manufacturer name as decoded text."""
+        return _decode_c_string(self.manufacturer_name)
+
+    @property
+    def model_name_text(self) -> str:
+        """Get model name as decoded text."""
+        return _decode_c_string(self.model_name)
+
+    @property
+    def serial_number_text(self) -> str:
+        """Get serial number as decoded text."""
+        return _decode_c_string(self.serial_number)
+
+    @property
+    def friendly_name_text(self) -> str:
+        """Get human-friendly device name as decoded text."""
+        return _decode_c_string(self.friendly_name)
+
+    @property
+    def device_location_text(self) -> str:
+        """Get device location as decoded text."""
+        return _decode_c_string(self.device_location)
+
+    @property
+    def device_id_text(self) -> str:
+        """Get unique device identifier as decoded text."""
+        return _decode_c_string(self.device_id)
+
+    @property
+    def custom_string_1_text(self) -> str:
+        """Get user-defined string field 1 as decoded text."""
+        return _decode_c_string(self.custom_string_1)
+
+    @property
+    def custom_string_2_text(self) -> str:
+        """Get user-defined string field 2 as decoded text."""
+        return _decode_c_string(self.custom_string_2)
+
+    @property
+    def custom_string_3_text(self) -> str:
+        """Get user-defined string field 3 as decoded text."""
+        return _decode_c_string(self.custom_string_3)
+
+    @classmethod
+    def from_bytes(cls, data: bytes) -> DataExtended:
+        """Parse from TLV packet data."""
+        if len(data) < cls.SIZE:
+            raise ValueError(f"Invalid DataExtended size: {len(data)} < {cls.SIZE}")
+
+        return cls(
+            manufacturer_name=data[0:32],
+            model_name=data[32:64],
+            serial_number=data[64:96],
+            friendly_name=data[96:128],
+            device_location=data[128:160],
+            device_id=data[160:192],
+            custom_string_1=data[192:224],
+            custom_string_2=data[224:256],
+            custom_string_3=data[256:288],
+        )
+
+    @classmethod
+    def from_strings(
+        cls,
+        *,
+        manufacturer_name: str = "",
+        model_name: str = "",
+        serial_number: str = "",
+        friendly_name: str = "",
+        device_location: str = "",
+        device_id: str = "",
+        custom_string_1: str = "",
+        custom_string_2: str = "",
+        custom_string_3: str = "",
+    ) -> DataExtended:
+        """Build extended identity data from user-facing string fields."""
+        return cls(
+            manufacturer_name=_encode_c_string(manufacturer_name, cls.FIELD_SIZE),
+            model_name=_encode_c_string(model_name, cls.FIELD_SIZE),
+            serial_number=_encode_c_string(serial_number, cls.FIELD_SIZE),
+            friendly_name=_encode_c_string(friendly_name, cls.FIELD_SIZE),
+            device_location=_encode_c_string(device_location, cls.FIELD_SIZE),
+            device_id=_encode_c_string(device_id, cls.FIELD_SIZE),
+            custom_string_1=_encode_c_string(custom_string_1, cls.FIELD_SIZE),
+            custom_string_2=_encode_c_string(custom_string_2, cls.FIELD_SIZE),
+            custom_string_3=_encode_c_string(custom_string_3, cls.FIELD_SIZE),
+        )
+
+    def to_bytes(self) -> bytes:
+        """Serialize to firmware packet bytes."""
+        return b"".join(
+            buf[: self.FIELD_SIZE].ljust(self.FIELD_SIZE, b"\x00")
+            for buf in (
+                self.manufacturer_name,
+                self.model_name,
+                self.serial_number,
+                self.friendly_name,
+                self.device_location,
+                self.device_id,
+                self.custom_string_1,
+                self.custom_string_2,
+                self.custom_string_3,
+            )
+        )
+
+
+@dataclass
 class GlobalConfig:
     """Complete device configuration parsed from TLV data.
 
@@ -1062,6 +1203,7 @@ class GlobalConfig:
     buzzers: list[PassiveBuzzer] = field(default_factory=list)
     nfc_configs: list[NfcConfig] = field(default_factory=list)
     flash_configs: list[FlashConfig] = field(default_factory=list)
+    data_extended: DataExtended | None = None
 
     # Metadata
     version: int = 0

--- a/src/opendisplay/models/config_json.py
+++ b/src/opendisplay/models/config_json.py
@@ -11,6 +11,7 @@ from typing import Any
 from .config import (
     BinaryInputs,
     DataBus,
+    DataExtended,
     DisplayConfig,
     FlashConfig,
     GlobalConfig,
@@ -370,6 +371,27 @@ def config_to_json(config: GlobalConfig) -> dict[str, Any]:
             }
         )
 
+    # Extended device identity strings (packet type 0x2c = 44)
+    if config.data_extended is not None:
+        ext = config.data_extended
+        packets.append(
+            {
+                "id": "44",
+                "name": "data_extended",
+                "fields": {
+                    "manufacturer_name": ext.manufacturer_name_text,
+                    "model_name": ext.model_name_text,
+                    "serial_number": ext.serial_number_text,
+                    "friendly_name": ext.friendly_name_text,
+                    "device_location": ext.device_location_text,
+                    "device_id": ext.device_id_text,
+                    "custom_string_1": ext.custom_string_1_text,
+                    "custom_string_2": ext.custom_string_2_text,
+                    "custom_string_3": ext.custom_string_3_text,
+                },
+            }
+        )
+
     return {
         "version": config.version,
         "minor_version": 1,  # JSON format version (not stored in device)
@@ -408,6 +430,7 @@ def config_from_json(data: dict[str, Any]) -> GlobalConfig:
     buzzers: list[PassiveBuzzer] = []
     nfc_configs: list[NfcConfig] = []
     flash_configs: list[FlashConfig] = []
+    data_extended: DataExtended | None = None
 
     version = data.get("version", 1)
     minor_version = data.get("minor_version", 0)
@@ -640,6 +663,19 @@ def config_from_json(data: dict[str, Any]) -> GlobalConfig:
                 )
             )
 
+        elif packet_id == 44:  # 0x2c = data_extended
+            data_extended = DataExtended.from_strings(
+                manufacturer_name=str(fields.get("manufacturer_name", "")),
+                model_name=str(fields.get("model_name", "")),
+                serial_number=str(fields.get("serial_number", "")),
+                friendly_name=str(fields.get("friendly_name", "")),
+                device_location=str(fields.get("device_location", "")),
+                device_id=str(fields.get("device_id", "")),
+                custom_string_1=str(fields.get("custom_string_1", "")),
+                custom_string_2=str(fields.get("custom_string_2", "")),
+                custom_string_3=str(fields.get("custom_string_3", "")),
+            )
+
     missing_required = []
     if system is None:
         missing_required.append("system")
@@ -671,6 +707,7 @@ def config_from_json(data: dict[str, Any]) -> GlobalConfig:
         buzzers=buzzers,
         nfc_configs=nfc_configs,
         flash_configs=flash_configs,
+        data_extended=data_extended,
         version=version,
         minor_version=minor_version,
         loaded=True,

--- a/src/opendisplay/protocol/config_parser.py
+++ b/src/opendisplay/protocol/config_parser.py
@@ -9,6 +9,7 @@ from ..exceptions import ConfigParseError
 from ..models.config import (
     BinaryInputs,
     DataBus,
+    DataExtended,
     DisplayConfig,
     FlashConfig,
     GlobalConfig,
@@ -42,6 +43,7 @@ PACKET_TYPE_TOUCH_CONTROLLER = 0x28
 PACKET_TYPE_PASSIVE_BUZZER = 0x29
 PACKET_TYPE_NFC_CONFIG = 0x2A
 PACKET_TYPE_FLASH_CONFIG = 0x2B
+PACKET_TYPE_DATA_EXTENDED = 0x2C
 
 WIFI_CONFIG_SIZE = 160
 WIFI_CONFIG_LEGACY_SIZE = 65
@@ -169,6 +171,7 @@ def parse_tlv_config(data: bytes, version: int = 1) -> GlobalConfig:
     buzzers = []
     nfc_configs = []
     flash_configs = []
+    data_extended = None
 
     for (packet_type, packet_number), packet_data in packets.items():
         if packet_type == PACKET_TYPE_SYSTEM:
@@ -199,6 +202,8 @@ def parse_tlv_config(data: bytes, version: int = 1) -> GlobalConfig:
             nfc_configs.append(NfcConfig.from_bytes(packet_data))
         elif packet_type == PACKET_TYPE_FLASH_CONFIG:
             flash_configs.append(FlashConfig.from_bytes(packet_data))
+        elif packet_type == PACKET_TYPE_DATA_EXTENDED:
+            data_extended = DataExtended.from_bytes(packet_data)
 
     missing_required = [
         name
@@ -232,6 +237,7 @@ def parse_tlv_config(data: bytes, version: int = 1) -> GlobalConfig:
         buzzers=buzzers,
         nfc_configs=nfc_configs,
         flash_configs=flash_configs,
+        data_extended=data_extended,
         version=version,  # From firmware wrapper
         minor_version=1,  # Not stored in device (only single version byte exists)
         loaded=True,
@@ -262,6 +268,7 @@ def _get_packet_size(packet_type: int) -> int | None:
         PACKET_TYPE_PASSIVE_BUZZER: 32,
         PACKET_TYPE_NFC_CONFIG: 32,
         PACKET_TYPE_FLASH_CONFIG: 32,
+        PACKET_TYPE_DATA_EXTENDED: DataExtended.SIZE,
     }
     return sizes.get(packet_type)
 

--- a/src/opendisplay/protocol/config_serializer.py
+++ b/src/opendisplay/protocol/config_serializer.py
@@ -9,6 +9,7 @@ if TYPE_CHECKING:
     from ..models.config import (
         BinaryInputs,
         DataBus,
+        DataExtended,
         DisplayConfig,
         FlashConfig,
         GlobalConfig,
@@ -39,6 +40,7 @@ PACKET_TYPE_TOUCH_CONTROLLER = 0x28
 PACKET_TYPE_PASSIVE_BUZZER = 0x29
 PACKET_TYPE_NFC_CONFIG = 0x2A
 PACKET_TYPE_FLASH_CONFIG = 0x2B
+PACKET_TYPE_DATA_EXTENDED = 0x2C
 
 
 def calculate_config_crc(data: bytes) -> int:
@@ -514,6 +516,11 @@ def serialize_wifi_config(config: WifiConfig) -> bytes:
     return config.to_bytes()
 
 
+def serialize_data_extended(config: DataExtended) -> bytes:
+    """Serialize DataExtended to 288 bytes."""
+    return config.to_bytes()
+
+
 def serialize_config(config: GlobalConfig) -> bytes:
     """Serialize complete GlobalConfig to TLV binary format.
 
@@ -616,6 +623,10 @@ def serialize_config(config: GlobalConfig) -> bytes:
             break
         packet_data += bytes([i, PACKET_TYPE_FLASH_CONFIG])
         packet_data += serialize_flash_config(flash)
+
+    if config.data_extended is not None:
+        packet_data += bytes([0, PACKET_TYPE_DATA_EXTENDED])
+        packet_data += serialize_data_extended(config.data_extended)
 
     # Validate size (max 4096 bytes including wrapper and CRC)
     total_size = len(packet_data) + 2  # +2 for CRC

--- a/tests/unit/test_data_extended.py
+++ b/tests/unit/test_data_extended.py
@@ -1,0 +1,295 @@
+"""Tests for the DataExtended identity packet (TLV type 0x2c, config.yaml id 44)."""
+
+from __future__ import annotations
+
+import struct
+
+import pytest
+
+from opendisplay.models.config import (
+    DataExtended,
+    DisplayConfig,
+    GlobalConfig,
+    ManufacturerData,
+    PowerOption,
+    SystemConfig,
+)
+from opendisplay.models.config_json import config_from_json, config_to_json
+from opendisplay.protocol.config_parser import parse_tlv_config
+from opendisplay.protocol.config_serializer import serialize_config, serialize_data_extended
+
+# ---------------------------------------------------------------------------
+# Helpers shared with test_models_new_packets.py pattern
+# ---------------------------------------------------------------------------
+
+
+def _packet(number: int, packet_type: int, payload: bytes) -> bytes:
+    return bytes([number, packet_type]) + payload
+
+
+def _system_payload() -> bytes:
+    return struct.pack("<HBBB", 1, 0, 0, 0) + (b"\x00" * 17)
+
+
+def _manufacturer_payload() -> bytes:
+    return struct.pack("<HBB", 1, 0, 1) + (b"\x00" * 18)
+
+
+def _power_payload() -> bytes:
+    return (
+        bytes([1])
+        + (1000).to_bytes(3, byteorder="little")
+        + struct.pack("<HbBBBBBHIH", 1000, 0, 0, 0xFF, 0xFF, 0, 1, 100, 0, 0)
+        + (b"\x00" * 10)
+    )
+
+
+def _display_payload() -> bytes:
+    return b"\x00" * 46
+
+
+def _required_tlv() -> bytes:
+    return (
+        _packet(0, 0x01, _system_payload())
+        + _packet(1, 0x02, _manufacturer_payload())
+        + _packet(2, 0x04, _power_payload())
+        + _packet(3, 0x20, _display_payload())
+    )
+
+
+def _field(text: str) -> bytes:
+    return text.encode("utf-8").ljust(32, b"\x00")
+
+
+def _data_extended_payload(**texts: str) -> bytes:
+    order = (
+        "manufacturer_name",
+        "model_name",
+        "serial_number",
+        "friendly_name",
+        "device_location",
+        "device_id",
+        "custom_string_1",
+        "custom_string_2",
+        "custom_string_3",
+    )
+    return b"".join(_field(texts.get(name, "")) for name in order)
+
+
+# ---------------------------------------------------------------------------
+# Dataclass
+# ---------------------------------------------------------------------------
+
+
+class TestDataExtended:
+    def test_from_bytes_parses_all_fields(self):
+        payload = _data_extended_payload(
+            manufacturer_name="OpenDisplay",
+            model_name="OD 4.26 Mono Kit",
+            serial_number="SN-0001",
+            friendly_name="Kitchen Tag",
+            device_location="Kitchen",
+            device_id="od-426-0001",
+            custom_string_1="one",
+            custom_string_2="two",
+            custom_string_3="three",
+        )
+        ext = DataExtended.from_bytes(payload)
+
+        assert ext.manufacturer_name_text == "OpenDisplay"
+        assert ext.model_name_text == "OD 4.26 Mono Kit"
+        assert ext.serial_number_text == "SN-0001"
+        assert ext.friendly_name_text == "Kitchen Tag"
+        assert ext.device_location_text == "Kitchen"
+        assert ext.device_id_text == "od-426-0001"
+        assert ext.custom_string_1_text == "one"
+        assert ext.custom_string_2_text == "two"
+        assert ext.custom_string_3_text == "three"
+
+    def test_empty_fields_decode_to_empty_string(self):
+        ext = DataExtended.from_bytes(bytes(DataExtended.SIZE))
+        assert ext.manufacturer_name_text == ""
+        assert ext.custom_string_3_text == ""
+
+    def test_default_instance_is_all_empty(self):
+        ext = DataExtended()
+        assert ext.to_bytes() == bytes(DataExtended.SIZE)
+        assert ext.friendly_name_text == ""
+
+    def test_from_strings_round_trip(self):
+        ext = DataExtended.from_strings(
+            manufacturer_name="Seeed Studio",
+            friendly_name="Desk Display",
+            device_id="rt-e1002-42",
+        )
+        ext2 = DataExtended.from_bytes(ext.to_bytes())
+        assert ext2 == ext
+        assert ext2.manufacturer_name_text == "Seeed Studio"
+        assert ext2.friendly_name_text == "Desk Display"
+        assert ext2.device_id_text == "rt-e1002-42"
+        assert ext2.model_name_text == ""
+
+    def test_from_strings_truncates_at_field_size(self):
+        ext = DataExtended.from_strings(friendly_name="x" * 40)
+        assert len(ext.friendly_name) == 32
+        assert ext.friendly_name_text == "x" * 32
+
+    def test_utf8_multibyte_strings(self):
+        ext = DataExtended.from_strings(device_location="Küche", friendly_name="Türschild")
+        ext2 = DataExtended.from_bytes(ext.to_bytes())
+        assert ext2.device_location_text == "Küche"
+        assert ext2.friendly_name_text == "Türschild"
+
+    def test_to_bytes_is_288_bytes(self):
+        assert len(DataExtended.from_strings().to_bytes()) == 288
+        assert DataExtended.SIZE == 288
+
+    def test_too_short_raises(self):
+        with pytest.raises(ValueError, match="Invalid DataExtended size"):
+            DataExtended.from_bytes(bytes(DataExtended.SIZE - 1))
+
+
+# ---------------------------------------------------------------------------
+# TLV parse / serialize
+# ---------------------------------------------------------------------------
+
+
+class TestDataExtendedTlv:
+    def test_parse_from_tlv(self):
+        tlv = _required_tlv() + _packet(4, 0x2C, _data_extended_payload(friendly_name="Hallway", device_id="tag-7"))
+        config = parse_tlv_config(tlv)
+
+        assert config.data_extended is not None
+        assert config.data_extended.friendly_name_text == "Hallway"
+        assert config.data_extended.device_id_text == "tag-7"
+
+    def test_absent_packet_leaves_none(self):
+        config = parse_tlv_config(_required_tlv())
+        assert config.data_extended is None
+
+    def test_packets_after_data_extended_still_parse(self):
+        # data_extended must not truncate parsing of packets that follow it.
+        tlv = (
+            _required_tlv()
+            + _packet(4, 0x2C, _data_extended_payload(serial_number="SN-9"))
+            + _packet(5, 0x21, b"\x00" * 22)  # LED config
+        )
+        config = parse_tlv_config(tlv)
+
+        assert config.data_extended is not None
+        assert config.data_extended.serial_number_text == "SN-9"
+        assert len(config.leds) == 1
+
+    def test_serialize_data_extended_matches_payload(self):
+        payload = _data_extended_payload(manufacturer_name="OpenDisplay", custom_string_2="two")
+        assert serialize_data_extended(DataExtended.from_bytes(payload)) == payload
+
+    def test_serialize_config_round_trip(self):
+        tlv = _required_tlv() + _packet(
+            4, 0x2C, _data_extended_payload(friendly_name="Bureau", device_location="Office")
+        )
+        config = parse_tlv_config(tlv)
+
+        # serialize_config wraps in [pad:2][version:1]...[crc:2]
+        reparsed = parse_tlv_config(serialize_config(config)[3:-2])
+
+        assert reparsed.data_extended is not None
+        assert reparsed.data_extended.friendly_name_text == "Bureau"
+        assert reparsed.data_extended.device_location_text == "Office"
+
+    def test_serialize_config_omits_when_none(self):
+        config = parse_tlv_config(_required_tlv())
+        reparsed = parse_tlv_config(serialize_config(config)[3:-2])
+        assert reparsed.data_extended is None
+
+
+# ---------------------------------------------------------------------------
+# JSON round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestDataExtendedJson:
+    def _minimal_config(self, **kwargs) -> GlobalConfig:
+        return GlobalConfig(
+            system=SystemConfig(
+                ic_type=2,
+                communication_modes=0x01,
+                device_flags=0x01,
+                pwr_pin=0x2B,
+                reserved=b"\x00" * 15,
+            ),
+            manufacturer=ManufacturerData(
+                manufacturer_id=1,
+                board_type=0,
+                board_revision=1,
+                reserved=b"\x00" * 18,
+            ),
+            power=PowerOption(
+                power_mode=1,
+                battery_capacity_mah=(2000).to_bytes(3, "little"),
+                sleep_timeout_ms=1000,
+                tx_power=8,
+                sleep_flags=0,
+                battery_sense_pin=0xFF,
+                battery_sense_enable_pin=0xFF,
+                battery_sense_flags=0,
+                capacity_estimator=1,
+                voltage_scaling_factor=100,
+                deep_sleep_current_ua=0,
+                deep_sleep_time_seconds=0,
+                reserved=b"\x00" * 10,
+            ),
+            displays=[
+                DisplayConfig(
+                    instance_number=0,
+                    display_technology=1,
+                    panel_ic_type=33,
+                    pixel_width=152,
+                    pixel_height=296,
+                    active_width_mm=0,
+                    active_height_mm=0,
+                    tag_type=0,
+                    rotation=0,
+                    reset_pin=0xFF,
+                    busy_pin=0xFF,
+                    dc_pin=0xFF,
+                    cs_pin=0xFF,
+                    data_pin=0,
+                    partial_update_support=1,
+                    color_scheme=0,
+                    transmission_modes=0x0A,
+                    clk_pin=0,
+                    reserved_pins=b"\x00" * 7,
+                    full_update_mC=0,
+                    reserved=b"\x00" * 13,
+                )
+            ],
+            version=1,
+            **kwargs,
+        )
+
+    def test_data_extended_round_trip(self):
+        ext = DataExtended.from_strings(
+            manufacturer_name="OpenDisplay",
+            model_name='7.3" Color Kit',
+            friendly_name="Wohnzimmer",
+            custom_string_3="drei",
+        )
+        cfg = self._minimal_config(data_extended=ext)
+
+        exported = config_to_json(cfg)
+        packet = next(p for p in exported["packets"] if p["id"] == "44")
+        assert packet["name"] == "data_extended"
+        assert packet["fields"]["friendly_name"] == "Wohnzimmer"
+
+        reimported = config_from_json(exported)
+        assert reimported.data_extended is not None
+        assert reimported.data_extended.manufacturer_name_text == "OpenDisplay"
+        assert reimported.data_extended.model_name_text == '7.3" Color Kit'
+        assert reimported.data_extended.friendly_name_text == "Wohnzimmer"
+        assert reimported.data_extended.custom_string_3_text == "drei"
+
+    def test_absent_data_extended_not_exported(self):
+        exported = config_to_json(self._minimal_config())
+        assert all(p["id"] != "44" for p in exported["packets"])
+        assert config_from_json(exported).data_extended is None

--- a/tests/unit/test_data_extended.py
+++ b/tests/unit/test_data_extended.py
@@ -13,6 +13,7 @@ from opendisplay.models.config import (
     ManufacturerData,
     PowerOption,
     SystemConfig,
+    WifiConfig,
 )
 from opendisplay.models.config_json import config_from_json, config_to_json
 from opendisplay.protocol.config_parser import parse_tlv_config
@@ -147,6 +148,14 @@ class TestDataExtended:
     def test_too_short_raises(self):
         with pytest.raises(ValueError, match="Invalid DataExtended size"):
             DataExtended.from_bytes(bytes(DataExtended.SIZE - 1))
+
+    def test_wifi_config_c_string_helpers_unchanged(self):
+        # The helpers moved to module level; the public WifiConfig staticmethods
+        # must keep delegating with identical behavior.
+        assert WifiConfig.encode_c_string("abc", 8) == b"abc\x00\x00\x00\x00\x00"
+        assert WifiConfig.encode_c_string("x" * 10, 4) == b"xxxx"
+        assert WifiConfig.decode_c_string(b"abc\x00garbage") == "abc"
+        assert WifiConfig.decode_c_string(bytes(8)) == ""
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Adds the extended device identity packet (config.yaml id 44): nine fixed 32-byte null-terminated UTF-8 strings (manufacturer_name, model_name, serial_number, friendly_name, device_location, device_id, custom_string_1-3). Single optional instance on GlobalConfig with full bytes and JSON round-trip, mirroring the wifi_config text-field handling via shared module-level C-string helpers.

Without this, devices emitting packet 0x2c hit the unknown-type break in the TLV parser and every packet after it was silently dropped.