### PR TITLE
add Seeed board types 9-13 from live config tool

### DIFF
--- a/src/opendisplay/models/enums.py
+++ b/src/opendisplay/models/enums.py
@@ -47,7 +47,11 @@ class DIYBoardType(IntEnum):
 
 
 class SeeedBoardType(IntEnum):
-    """Seeed board types."""
+    """Seeed board types.
+
+    Mirrors the ``board_type`` ``conditional_enum`` for ``manufacturer_id: 1``
+    in the Web config tool's ``config.yaml`` (source of truth).
+    """
 
     EE04 = 0
     EN04 = 1
@@ -58,6 +62,11 @@ class SeeedBoardType(IntEnum):
     EE05 = 6
     EN05 = 7
     RETERMINAL_E1003 = 8
+    RETERMINAL_STICKY = 9
+    OPENDISPLAY_426_MONO_KIT = 10
+    OPENDISPLAY_73_COLOR_KIT = 11
+    RETERMINAL_E1001 = 12
+    RETERMINAL_E1002 = 13
 
 
 class WaveshareBoardType(IntEnum):
@@ -196,6 +205,11 @@ _BOARD_TYPE_NAMES_SEEED: Final[dict[SeeedBoardType, str]] = {
     SeeedBoardType.EE05: "EE05",
     SeeedBoardType.EN05: "EN05",
     SeeedBoardType.RETERMINAL_E1003: "reTerminal E1003",
+    SeeedBoardType.RETERMINAL_STICKY: "reTerminal Sticky",
+    SeeedBoardType.OPENDISPLAY_426_MONO_KIT: 'OpenDisplay 4.26" Mono Kit',
+    SeeedBoardType.OPENDISPLAY_73_COLOR_KIT: 'OpenDisplay 7.3" Color Kit',
+    SeeedBoardType.RETERMINAL_E1001: "reTerminal E1001",
+    SeeedBoardType.RETERMINAL_E1002: "reTerminal E1002",
 }
 
 _BOARD_TYPE_NAMES_WAVESHARE: Final[dict[WaveshareBoardType, str]] = {

--- a/tests/unit/test_module_enums.py
+++ b/tests/unit/test_module_enums.py
@@ -90,11 +90,17 @@ class TestBoardTypeEnums:
         assert DIYBoardType.CUSTOM == 0
 
     def test_seeed_board_type_values(self):
-        """Test Seeed board type values."""
+        """Test Seeed board type values (mirror config.yaml board_type enum)."""
         assert SeeedBoardType.EE04 == 0
         assert SeeedBoardType.EN04 == 1
         assert SeeedBoardType.EE05 == 6
         assert SeeedBoardType.EN05 == 7
+        assert SeeedBoardType.RETERMINAL_E1003 == 8
+        assert SeeedBoardType.RETERMINAL_STICKY == 9
+        assert SeeedBoardType.OPENDISPLAY_426_MONO_KIT == 10
+        assert SeeedBoardType.OPENDISPLAY_73_COLOR_KIT == 11
+        assert SeeedBoardType.RETERMINAL_E1001 == 12
+        assert SeeedBoardType.RETERMINAL_E1002 == 13
 
     def test_waveshare_board_type_values(self):
         """Test Waveshare board type values."""
@@ -125,6 +131,13 @@ class TestBoardTypeEnums:
         assert get_board_type_name(BoardManufacturer.SOLUM, 4) == "M3 Silabs Pro"
         assert get_board_type_name(BoardManufacturer.SOLUM, 6) == "M3 Silabs Peghook"
         assert get_board_type_name(BoardManufacturer.OPENDISPLAY, 0) == "OD01"
+        # Seeed: types 9-13 added on the live config tool (reTerminal Sticky,
+        # OpenDisplay kits manufactured by Seeed, and older reTerminal models).
+        assert get_board_type_name(BoardManufacturer.SEEED, 9) == "reTerminal Sticky"
+        assert get_board_type_name(BoardManufacturer.SEEED, 10) == 'OpenDisplay 4.26" Mono Kit'
+        assert get_board_type_name(BoardManufacturer.SEEED, 11) == 'OpenDisplay 7.3" Color Kit'
+        assert get_board_type_name(BoardManufacturer.SEEED, 12) == "reTerminal E1001"
+        assert get_board_type_name(BoardManufacturer.SEEED, 13) == "reTerminal E1002"
         assert get_board_type_name(BoardManufacturer.SEEED, 99) is None
         assert get_board_type_name(99, 0) is None
 


### PR DESCRIPTION
Syncs SeeedBoardType with the board_type conditional_enum served at opendisplay.org/firmware/toolbox/config.yaml, which is ahead of the Web git repo: reTerminal Sticky (9), OpenDisplay 4.26" Mono Kit (10), OpenDisplay 7.3" Color Kit (11), reTerminal E1001 (12) and reTerminal E1002 (13). Devices reporting these types previously fell back to the raw int with no display name.