### PR TITLE
perf: defer full-frame compression when a partial upload may succeed

### DIFF
--- a/src/opendisplay/device.py
+++ b/src/opendisplay/device.py
@@ -1132,11 +1132,16 @@ class OpenDisplayDevice:
         display_cfg = self._config.displays[0] if (self._config and self._config.displays) else None
         supports_compression = display_cfg.supports_zip if display_cfg else True
 
+        # When a partial upload may succeed, defer full-frame compression: it is
+        # pure waste if the partial path handles the update. _dispatch_upload
+        # compresses lazily on the full-upload fallback.
+        prepare_compress = compress and supports_compression and state is None
+
         # Prepare image (fit, dither, encode, compress)
         image_data, compressed_data, processed_image = self._prepare_image(
             image,
             dither_mode,
-            compress and supports_compression,
+            prepare_compress,
             serpentine=serpentine,
             exposure=exposure,
             saturation=saturation,
@@ -1240,9 +1245,14 @@ class OpenDisplayDevice:
         display_cfg = self._config.displays[0] if (self._config and self._config.displays) else None
         supports_compression = display_cfg.supports_zip if display_cfg else True
         uses_zipxl_window = bool(display_cfg and display_cfg.supports_zipxl)
-        if compress and supports_compression and uses_zipxl_window:
-            if compressed_data is None or zlib_window_bits(compressed_data) != ZIPXL_ZLIB_WINDOW_BITS:
-                compressed_data = compress_image_data(image_data, level=6, window_bits=ZIPXL_ZLIB_WINDOW_BITS)
+        if compress and supports_compression:
+            if uses_zipxl_window:
+                if compressed_data is None or zlib_window_bits(compressed_data) != ZIPXL_ZLIB_WINDOW_BITS:
+                    compressed_data = compress_image_data(image_data, level=6, window_bits=ZIPXL_ZLIB_WINDOW_BITS)
+            elif compressed_data is None:
+                # Lazy compression for the deferred/partial-fallback path: matches
+                # what prepare_image would have produced for a non-ZIPXL device.
+                compressed_data = compress_image_data(image_data, level=6, window_bits=DEFAULT_ZLIB_WINDOW_BITS)
 
         within_compressed_limit = compressed_data is not None and (
             uses_zipxl_window or len(compressed_data) < MAX_COMPRESSED_SIZE


### PR DESCRIPTION
## Summary

`upload_image` always encoded **and** zlib-compressed the entire frame before attempting the partial (0x76) path. When the partial upload succeeds (the common case for small changes), that full-frame compression is pure waste — 2.7 ms @800×480, 15.7 ms @1600×1200.

This PR defers full-frame compression when `state is not None`:
- `upload_image` prepares with `compress=False` when a partial upload may be attempted.
- `_dispatch_upload` compresses lazily on the full-upload fallback. The ZIPXL path already recompressed on window mismatch; this extends the same lazy behavior to the non-ZIPXL branch.

## Correctness

- **`state is None`** (plain full upload): unchanged — `prepare_image` still compresses eagerly, and `_dispatch_upload`'s new `elif compressed_data is None` branch is never taken.
- **`state is not None`, partial succeeds**: full-frame compression skipped entirely (the win).
- **`state is not None`, fallback to full**: `_dispatch_upload` compresses with the *same* window bits `prepare_image` would have used (ZIPXL=9 / DEFAULT=15), so the bytes on the wire are identical to before — just computed later.

## Test plan

- [x] `uv run pytest -q` → 439 passed
- [x] `ruff check`, `ruff format`, `mypy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)