### PR TITLE
fix: serialize device commands and clear session on disconnect (C5, M9)

### DIFF
--- a/src/opendisplay/device.py
+++ b/src/opendisplay/device.py
@@ -3,10 +3,13 @@
 
 from __future__ import annotations
 
+import asyncio
+import functools
 import logging
 import time
-from collections.abc import Callable
-from typing import TYPE_CHECKING
+from collections.abc import AsyncIterator, Awaitable, Callable
+from contextlib import asynccontextmanager
+from typing import TYPE_CHECKING, TypeVar
 
 from epaper_dithering import ColorScheme, DitherMode, dither_image
 from PIL import Image
@@ -265,6 +268,32 @@ def prepare_image(
     return image_data, compressed_data, dithered
 
 
+_T = TypeVar("_T")
+
+
+def _serialized(
+    func: Callable[..., Awaitable[_T]],
+) -> Callable[..., Awaitable[_T]]:
+    """Serialize a device command against all other commands on the same device.
+
+    Holds the per-device command lock across the whole call so that no two
+    command round-trips interleave — this prevents AES-CCM nonce reuse and
+    notification-queue response mixups under concurrency. The lock is reentrant
+    within a single task, so a command that internally triggers another
+    ``@_serialized`` call (e.g. an upload re-authenticating mid-stream) does not
+    deadlock.
+    """
+
+    @functools.wraps(func)
+    async def wrapper(self: OpenDisplayDevice, *args: object, **kwargs: object) -> _T:
+        # This decorator is part of OpenDisplayDevice's own machinery; the
+        # "protected" transaction helper is intentionally used here.
+        async with self._transaction():  # pylint: disable=protected-access
+            return await func(self, *args, **kwargs)
+
+    return wrapper
+
+
 class OpenDisplayDevice:
     """OpenDisplay BLE e-paper device.
 
@@ -363,6 +392,10 @@ class OpenDisplayDevice:
         self._nonce_counter: int = 0
         self._auth_time: float | None = None  # monotonic timestamp of last successful auth
 
+        # Serializes command round-trips (see _serialized / _transaction).
+        self._command_lock = asyncio.Lock()
+        self._lock_owner: asyncio.Task[object] | None = None
+
     async def __aenter__(self) -> OpenDisplayDevice:
         """Connect and optionally interrogate device."""
 
@@ -398,6 +431,7 @@ class OpenDisplayDevice:
             self._timeout,
             max_attempts=self._max_attempts,
             use_services_cache=self._use_services_cache,
+            disconnected_callback=self._on_ble_disconnect,
         )
 
         await self._conn.connect()
@@ -426,6 +460,8 @@ class OpenDisplayDevice:
         """Disconnect from device."""
         if self._connection is not None:
             await self._conn.disconnect()
+        # Forget the session so a reused device object re-authenticates cleanly.
+        self._clear_session()
 
     @property
     def _conn(self) -> BLEConnection:
@@ -433,6 +469,41 @@ class OpenDisplayDevice:
         if self._connection is None:
             raise RuntimeError("Device not connected")
         return self._connection
+
+    @asynccontextmanager
+    async def _transaction(self) -> AsyncIterator[None]:
+        """Hold the command lock for the duration of a command round-trip.
+
+        Reentrant per task: if the current task already owns the lock (e.g. a
+        re-authentication triggered from within an upload), the nested call runs
+        without re-acquiring instead of deadlocking.
+        """
+        current = asyncio.current_task()
+        if self._lock_owner is current:
+            yield
+            return
+        async with self._command_lock:
+            self._lock_owner = current
+            try:
+                yield
+            finally:
+                self._lock_owner = None
+
+    def _clear_session(self) -> None:
+        """Drop any encryption session state.
+
+        Called on disconnect so a reused device object does not encrypt against
+        a session the firmware has already torn down.
+        """
+        self._session_key = None
+        self._session_id = None
+        self._nonce_counter = 0
+        self._auth_time = None
+
+    def _on_ble_disconnect(self) -> None:
+        """Handle an unexpected BLE drop: forget the (now-dead) session."""
+        _LOGGER.debug("Link to %s dropped; clearing session state", self.mac_address)
+        self._clear_session()
 
     async def _write(self, data: bytes) -> None:
         """Write a command, encrypting it if an active session exists."""
@@ -487,6 +558,7 @@ class OpenDisplayDevice:
             )
         return raw
 
+    @_serialized
     async def authenticate(self, key: bytes) -> None:
         """Perform two-step challenge-response authentication with the device.
 
@@ -672,6 +744,7 @@ class OpenDisplayDevice:
                 pass
         return bytes.fromhex(self.mac_address.replace(":", ""))[-3:]
 
+    @_serialized
     async def interrogate(self) -> GlobalConfig:
         """Read device configuration from device.
 
@@ -727,6 +800,7 @@ class OpenDisplayDevice:
 
         return self._config
 
+    @_serialized
     async def read_firmware_version(self) -> FirmwareVersion:
         """Read firmware version from device.
 
@@ -754,6 +828,7 @@ class OpenDisplayDevice:
 
         return self._fw_version
 
+    @_serialized
     async def reboot(self) -> None:
         """Reboot the device.
 
@@ -779,6 +854,7 @@ class OpenDisplayDevice:
         # Device will reset immediately - no ACK expected
         _LOGGER.info("Reboot command sent to %s - device will reset (connection will drop)", self.mac_address)
 
+    @_serialized
     async def trigger_dfu_bootloader(self) -> None:
         """Trigger the DFU bootloader on nRF devices (command 0x0051).
 
@@ -841,6 +917,7 @@ class OpenDisplayDevice:
         """
         return await self._conn.clear_cache()
 
+    @_serialized
     async def activate_led(
         self,
         led_instance: int,
@@ -894,6 +971,7 @@ class OpenDisplayDevice:
         validate_ack_response(response, CommandCode.LED_ACTIVATE)
         return response
 
+    @_serialized
     async def activate_buzzer(
         self,
         buzzer_instance: int,
@@ -926,6 +1004,7 @@ class OpenDisplayDevice:
         validate_ack_response(response, CommandCode.BUZZER_ACTIVATE)
         return response
 
+    @_serialized
     async def write_config(self, config: GlobalConfig) -> None:
         """Write configuration to device.
 
@@ -1068,6 +1147,7 @@ class OpenDisplayDevice:
             rotate=rotate,
         )
 
+    @_serialized
     async def upload_image(
         self,
         image: Image.Image,
@@ -1175,6 +1255,7 @@ class OpenDisplayDevice:
             self._update_partial_state(state, processed_image, image_data, full_upload_etag)
         return processed_image
 
+    @_serialized
     async def upload_prepared_image(
         self,
         prepared_data: tuple[bytes, bytes | None, Image.Image],

--- a/src/opendisplay/transport/connection.py
+++ b/src/opendisplay/transport/connection.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 from bleak import BleakClient, BleakScanner
@@ -36,6 +37,7 @@ class BLEConnection:
         timeout: float = 10.0,
         max_attempts: int = 4,
         use_services_cache: bool = True,
+        disconnected_callback: Callable[[], None] | None = None,
     ):
         """Initialize BLE connection manager.
 
@@ -45,12 +47,15 @@ class BLEConnection:
             timeout: Connection timeout in seconds (default: 10)
             max_attempts: Maximum connection attempts for bleak-retry-connector (default: 4)
             use_services_cache: Enable GATT service caching for faster reconnections (default: True)
+            disconnected_callback: Optional callback invoked when the link drops
+                (either an unexpected disconnect or a graceful one).
         """
         self.mac_address = mac_address
         self.ble_device = ble_device
         self.timeout = timeout
         self.max_attempts = max_attempts
         self.use_services_cache = use_services_cache
+        self._disconnected_callback = disconnected_callback
 
         self._client: BleakClient | None = None
         self._notification_queue: asyncio.Queue[bytes] = asyncio.Queue()
@@ -142,6 +147,7 @@ class BLEConnection:
             max_attempts=self.max_attempts,
             use_services_cache=use_services_cache,
             timeout=self.timeout,
+            disconnected_callback=self._on_disconnect,
         )
 
         _LOGGER.debug("Connected to %s", self.mac_address)
@@ -232,6 +238,19 @@ class BLEConnection:
         )
 
         _LOGGER.debug("Notifications started")
+
+    def _on_disconnect(self, _client: BleakClient) -> None:
+        """Handle an unexpected or graceful BLE disconnect.
+
+        Notifies the owner (e.g. so it can drop stale encryption session state)
+        via the registered ``disconnected_callback``.
+        """
+        _LOGGER.debug("BLE link to %s dropped", self.mac_address)
+        if self._disconnected_callback is not None:
+            try:
+                self._disconnected_callback()
+            except Exception:  # noqa: BLE001 - best-effort notification
+                _LOGGER.debug("disconnected_callback raised", exc_info=True)
 
     def _notification_callback(self, _sender: BleakGATTCharacteristic, data: bytearray) -> None:
         """Handle incoming BLE notifications.

--- a/tests/unit/test_device_command_serialization.py
+++ b/tests/unit/test_device_command_serialization.py
@@ -1,0 +1,84 @@
+"""Tests for command serialization and session-state clearing (C5 / M9)."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock
+
+import pytest
+from epaper_dithering import ColorScheme
+
+from opendisplay import OpenDisplayDevice
+from opendisplay.models.capabilities import DeviceCapabilities
+from opendisplay.transport.connection import BLEConnection
+
+
+def _make_device() -> OpenDisplayDevice:
+    caps = DeviceCapabilities(width=2, height=2, color_scheme=ColorScheme.MONO)
+    return OpenDisplayDevice(mac_address="AA:BB:CC:DD:EE:FF", capabilities=caps)
+
+
+@pytest.mark.asyncio
+async def test_transaction_serializes_concurrent_commands() -> None:
+    """Two command round-trips must not interleave."""
+    device = _make_device()
+    order: list[str] = []
+
+    async def op(name: str, hold: float) -> None:
+        async with device._transaction():
+            order.append(f"{name}-start")
+            await asyncio.sleep(hold)
+            order.append(f"{name}-end")
+
+    # gather schedules A first, so A acquires the lock; B must wait for A to finish.
+    await asyncio.gather(op("A", 0.02), op("B", 0.0))
+
+    assert order == ["A-start", "A-end", "B-start", "B-end"]
+
+
+@pytest.mark.asyncio
+async def test_transaction_is_reentrant_within_a_task() -> None:
+    """A nested transaction in the same task must not deadlock."""
+    device = _make_device()
+
+    async def nested() -> str:
+        async with device._transaction():
+            async with device._transaction():
+                return "ok"
+
+    assert await asyncio.wait_for(nested(), timeout=1.0) == "ok"
+
+
+def test_clear_session_resets_all_session_state() -> None:
+    device = _make_device()
+    device._session_key = b"k" * 16
+    device._session_id = b"i" * 8
+    device._nonce_counter = 5
+    device._auth_time = 123.0
+
+    device._clear_session()
+
+    assert device._session_key is None
+    assert device._session_id is None
+    assert device._nonce_counter == 0
+    assert device._auth_time is None
+
+
+def test_on_ble_disconnect_clears_session() -> None:
+    device = _make_device()
+    device._session_key = b"k" * 16
+    device._nonce_counter = 9
+
+    device._on_ble_disconnect()
+
+    assert device._session_key is None
+    assert device._nonce_counter == 0
+
+
+def test_connection_disconnect_callback_is_invoked() -> None:
+    calls: list[bool] = []
+    conn = BLEConnection("AA:BB:CC:DD:EE:FF", disconnected_callback=lambda: calls.append(True))
+
+    conn._on_disconnect(MagicMock())
+
+    assert calls == [True]


### PR DESCRIPTION
## Summary

Two related concurrency/session-lifecycle correctness fixes.

### C5 — command serialization (🔴)

There was no lock around the write→read command transaction. Two concurrent commands — e.g. `asyncio.gather(dev.upload_image(...), dev.read_firmware_version())`, or re-entry from a progress callback — could:
- read the same `_nonce_counter` and produce an identical AES-CCM `(key, nonce)` pair (breaks CCM confidentiality/integrity; firmware also rejects the replay and eventually clears the session, killing an in-flight upload); and
- read each other's responses off the shared notification queue.

Fix: a per-device command lock (`@_serialized`) held across each full command round-trip, with the nonce increment inside it. The lock is **reentrant per asyncio task**, so a command that internally re-authenticates mid-stream (upload → `_write` → `_reauthenticate_if_needed` → `authenticate`) does not deadlock. Applied to all public command methods (`authenticate`, `interrogate`, `read_firmware_version`, `reboot`, `trigger_dfu_bootloader`, `activate_led`, `activate_buzzer`, `write_config`, `upload_image`, `upload_prepared_image`).

### M9 — session cleared on disconnect (🟠)

`disconnect()`/`__aexit__` kept `_session_key`/`_session_id`/`_nonce_counter`, and no bleak `disconnected_callback` was registered. Reconnecting the same device object then encrypted against a session the firmware no longer has → misleading `AuthenticationRequiredError`.

Fix: clear session state in `__aexit__`, and register a `disconnected_callback` on the BLE connection that drops session state on an unexpected drop.

## Test plan

- [x] `uv run pytest -q` → 444 passed (5 new tests: serialization ordering, reentrancy, `_clear_session`, disconnect-clears-session, connection callback)
- [x] `ruff`, `mypy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)