### PR TITLE
fix: drain stale notifications and recover on read timeout (C6)

### DIFF
--- a/src/opendisplay/transport/connection.py
+++ b/src/opendisplay/transport/connection.py
@@ -243,6 +243,27 @@ class BLEConnection:
         # Put notification in queue for processing
         self._notification_queue.put_nowait(bytes(data))
 
+    def drain_notifications(self) -> int:
+        """Discard any queued notifications and return how many were dropped.
+
+        The queue has no request/response correlation, so a stale frame — e.g. a
+        response that arrived just after its read timed out, or an unsolicited
+        firmware frame — would otherwise be returned as the answer to the *next*
+        command and desync every subsequent read by one. Draining before writing
+        a command clears such leftovers; in healthy stop-and-wait operation the
+        queue is already empty here, so this is a no-op.
+        """
+        dropped = 0
+        while True:
+            try:
+                self._notification_queue.get_nowait()
+            except asyncio.QueueEmpty:
+                break
+            dropped += 1
+        if dropped:
+            _LOGGER.warning("Discarded %d stale notification(s) before command", dropped)
+        return dropped
+
     async def write_command(self, data: bytes) -> None:
         """Write command to device.
 
@@ -257,6 +278,10 @@ class BLEConnection:
 
         if not self._notification_characteristic:
             raise BLEConnectionError("Notifications not set up")
+
+        # Clear any stale/unsolicited frames so this command's response is read
+        # from a clean queue (see drain_notifications).
+        self.drain_notifications()
 
         try:
             await self._client.write_gatt_char(
@@ -285,6 +310,13 @@ class BLEConnection:
                 timeout=timeout,
             )
         except asyncio.TimeoutError as e:
+            # asyncio.wait_for can cancel queue.get() *after* an item was handed
+            # to it, silently dropping that item. Re-check synchronously before
+            # giving up so a response delivered during cancellation is not lost.
+            try:
+                return self._notification_queue.get_nowait()
+            except asyncio.QueueEmpty:
+                pass
             raise BLETimeoutError(f"No response received within {timeout}s") from e
 
     @property

--- a/tests/unit/test_connection_notification_queue.py
+++ b/tests/unit/test_connection_notification_queue.py
@@ -1,0 +1,49 @@
+"""Tests for notification-queue draining and timeout recovery (C6)."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from opendisplay.exceptions import BLETimeoutError
+from opendisplay.transport.connection import BLEConnection
+
+
+def test_drain_notifications_discards_all_queued() -> None:
+    conn = BLEConnection("AA:BB:CC:DD:EE:FF")
+    conn._notification_queue.put_nowait(b"a")
+    conn._notification_queue.put_nowait(b"b")
+
+    assert conn.drain_notifications() == 2
+    assert conn._notification_queue.empty()
+
+
+def test_drain_notifications_empty_queue_is_noop() -> None:
+    conn = BLEConnection("AA:BB:CC:DD:EE:FF")
+    assert conn.drain_notifications() == 0
+
+
+@pytest.mark.asyncio
+async def test_read_response_recovers_item_delivered_during_cancellation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If wait_for cancels queue.get() after an item was handed over, the item
+    is recovered synchronously instead of being lost."""
+    conn = BLEConnection("AA:BB:CC:DD:EE:FF")
+    conn._notification_queue.put_nowait(b"late-response")
+
+    def fake_wait_for(coro: object, timeout: float) -> object:
+        coro.close()  # type: ignore[attr-defined]  # avoid unawaited-coroutine warning
+        raise asyncio.TimeoutError
+
+    monkeypatch.setattr(asyncio, "wait_for", fake_wait_for)
+
+    assert await conn.read_response(timeout=0.01) == b"late-response"
+
+
+@pytest.mark.asyncio
+async def test_read_response_times_out_when_queue_empty() -> None:
+    conn = BLEConnection("AA:BB:CC:DD:EE:FF")
+    with pytest.raises(BLETimeoutError):
+        await conn.read_response(timeout=0.01)


### PR DESCRIPTION
## Summary

The shared notification queue had no request/response correlation and was never flushed on error (`transport/connection.py`). If a response arrived just after its `BLETimeoutError` fired (e.g. an END ACK at 90.001 s), it was returned as the answer to the **next** command, and every subsequent read stayed off-by-one until reconnect. Any unsolicited frame (late 0x74, firmware debug frame) had the same effect.

## Fix

- **`drain_notifications()`** — discards any queued frames and returns the count. `write_command` drains before sending, so each command reads from a clean queue. In healthy stop-and-wait operation the queue is already empty here, so this is a no-op (and logs a warning only when it actually drops something, giving visibility into a desync).
- **`read_response()`** — `asyncio.wait_for` can cancel `queue.get()` *after* an item was handed to it, silently dropping it. Re-check `get_nowait()` on timeout before raising, so a response delivered during cancellation is not lost.

## Test plan

- [x] `uv run pytest -q` → 443 passed (4 new: drain drops all / drain empty no-op / read recovers item delivered during cancellation / read still times out on empty queue)
- [x] `ruff`, `mypy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)