### PR TITLE
fix: write_config first chunk must carry 200 data bytes (C4)

### DIFF
--- a/src/opendisplay/protocol/commands.py
+++ b/src/opendisplay/protocol/commands.py
@@ -301,8 +301,15 @@ def build_write_config_command(config_data: bytes) -> tuple[bytes, list[bytes]]:
     Protocol:
     - Single chunk (≤200 bytes): [0x00][0x41][config_data]
     - Multi-chunk (>200 bytes):
-      - First: [0x00][0x41][total_size:2LE][first_198_bytes]
+      - First: [0x00][0x41][total_size:2LE][first_200_bytes]
       - Rest: [0x00][0x42][chunk_data] (up to 200 bytes each)
+
+    The first chunk carries a full 200 data bytes (payload = size(2) + 200 = 202
+    bytes). Firmware only enters chunked mode when the payload length exceeds 200
+    and expects exactly [total:2LE][200 data]; a 198-byte first chunk (200-byte
+    payload) makes it take the single-chunk path and store the size header plus a
+    truncated config, then NACK every following 0x42 chunk, and also breaks its
+    ``expectedChunks = ceil(total / 200)`` accounting.
 
     Args:
         config_data: Complete serialized config data
@@ -320,7 +327,7 @@ def build_write_config_command(config_data: bytes) -> tuple[bytes, list[bytes]]:
 
         # Large config (>200 bytes)
         first_cmd, chunks = build_write_config_command(large_config)
-        # first_cmd: [0x00][0x41][total_size:2LE][first_198_bytes]
+        # first_cmd: [0x00][0x41][total_size:2LE][first_200_bytes]
         # chunks: [[0x00][0x42][chunk_data], ...]
     """
     cmd_write = CommandCode.WRITE_CONFIG.to_bytes(2, byteorder="big")
@@ -333,9 +340,9 @@ def build_write_config_command(config_data: bytes) -> tuple[bytes, list[bytes]]:
         return cmd_write + config_data, []
 
     # Multi-chunk mode (>200 bytes)
-    # First chunk: [cmd][total_size:2LE][first_198_bytes]
+    # First chunk: [cmd][total_size:2LE][first_200_bytes]
     total_size = config_len.to_bytes(2, byteorder="little")
-    first_chunk_data_size = CONFIG_CHUNK_SIZE - 2  # 198 bytes
+    first_chunk_data_size = CONFIG_CHUNK_SIZE  # 200 bytes
     first_chunk = cmd_write + total_size + config_data[:first_chunk_data_size]
 
     # Remaining chunks: [cmd][chunk_data] (up to 200 bytes each)

--- a/tests/unit/test_protocol_commands.py
+++ b/tests/unit/test_protocol_commands.py
@@ -4,6 +4,7 @@ from opendisplay.models.buzzer_activate import BuzzerActivateConfig
 from opendisplay.models.led_flash import LedFlashConfig, LedFlashStep
 from opendisplay.protocol.commands import (
     CHUNK_SIZE,
+    CONFIG_CHUNK_SIZE,
     CommandCode,
     build_buzzer_activate_command,
     build_direct_write_data_command,
@@ -14,6 +15,7 @@ from opendisplay.protocol.commands import (
     build_read_config_command,
     build_read_fw_version_command,
     build_reboot_command,
+    build_write_config_command,
 )
 
 
@@ -214,3 +216,42 @@ class TestBuildBuzzerActivateCommand:
         config = BuzzerActivateConfig.single_tone(frequency_hz=1000, duration_ms=100)
         with pytest.raises(ValueError, match="out of range"):
             build_buzzer_activate_command(256, config)
+
+
+class TestWriteConfigChunking:
+    """WRITE_CONFIG chunking must match the firmware's expectations (C4)."""
+
+    def test_single_chunk_when_within_limit(self):
+        data = b"\xab" * CONFIG_CHUNK_SIZE  # exactly 200 bytes -> single chunk
+        first, chunks = build_write_config_command(data)
+        assert chunks == []
+        assert first == CommandCode.WRITE_CONFIG.to_bytes(2, "big") + data
+
+    def test_first_chunk_carries_full_200_data_bytes(self):
+        # >200 bytes triggers chunked mode; the first chunk must carry a full
+        # 200 data bytes (payload = size(2) + 200 = 202 > 200) so the firmware
+        # enters chunked mode instead of the single-chunk path.
+        total = CONFIG_CHUNK_SIZE + 50  # 250 bytes
+        data = bytes(range(256))[:total]
+        first, chunks = build_write_config_command(data)
+
+        cmd_write = CommandCode.WRITE_CONFIG.to_bytes(2, "big")
+        # first = cmd(2) + total_size(2 LE) + 200 data
+        assert first[:2] == cmd_write
+        assert first[2:4] == total.to_bytes(2, "little")
+        assert first[4:] == data[:CONFIG_CHUNK_SIZE]
+        assert len(first[4:]) == CONFIG_CHUNK_SIZE
+
+        # remaining 50 bytes in a single 0x42 continuation chunk
+        cmd_chunk = CommandCode.WRITE_CONFIG_CHUNK.to_bytes(2, "big")
+        assert len(chunks) == 1
+        assert chunks[0] == cmd_chunk + data[CONFIG_CHUNK_SIZE:]
+
+    def test_chunk_count_matches_ceil_total_over_200(self):
+        import math
+
+        for total in (201, 400, 401, 605):
+            data = bytes((i % 256 for i in range(total)))
+            first, chunks = build_write_config_command(data)
+            # first chunk (200) + continuations (200 each) == ceil(total/200) chunks
+            assert 1 + len(chunks) == math.ceil(total / CONFIG_CHUNK_SIZE)


### PR DESCRIPTION
## Summary

The chunked `write_config` first packet (`build_write_config_command`) sent `total_size(2) + 198 data = 200` payload bytes. But the firmware:
- enters chunked mode **only when the payload length exceeds 200**, and
- expects the first chunk to be exactly `[total:2LE][200 data]` = 202 payload bytes.

With a 200-byte payload, the firmware took the **single-chunk** path and `saveConfig()`'d the raw 200 bytes (the 2-byte size header plus a truncated config stored as the whole config), then NACKed every subsequent `0x42` chunk. The 198-byte first chunk also broke the firmware's `expectedChunks = ceil(total / 200)` accounting.

Since a realistic full config (system + manufacturer + power + display + …) exceeds 200 bytes, `write_config` was broken against this firmware for most real configs.

## Fix

The first chunk now carries a full **200** data bytes (`payload = size(2) + 200 = 202`), and continuations remain 200 bytes each — so the firmware enters chunked mode and its `ceil(total/200)` accounting matches.

## Test plan

- [x] `uv run pytest -q` → 442 passed (3 new tests: single-chunk boundary, first chunk carries 200 data bytes, chunk count == ceil(total/200))
- [x] `ruff`, `mypy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)