### PR TITLE
fix: partial-upload guards — MONO-only, 8-align, NACK fallback, etag commit (M1/M2/M10)

### DIFF
--- a/src/opendisplay/device.py
+++ b/src/opendisplay/device.py
@@ -46,7 +46,6 @@ from .models.enums import BoardManufacturer, FitMode, RefreshMode, Rotation
 from .models.firmware import FirmwareVersion
 from .models.led_flash import LedFlashConfig
 from .partial import (
-    ERR_ETAG_MISMATCH,
     PARTIAL_FLAG_COMPRESSED,
     PartialState,
     _generate_etag,
@@ -1161,7 +1160,7 @@ class OpenDisplayDevice:
 
         upload_refresh_mode = RefreshMode.FULL if state is not None else refresh_mode
         full_upload_etag = _generate_etag() if state is not None else None
-        await self._dispatch_upload(
+        etag_committed = await self._dispatch_upload(
             image_data,
             upload_refresh_mode,
             compress,
@@ -1172,7 +1171,7 @@ class OpenDisplayDevice:
 
         _LOGGER.info("Image upload complete")
         if state is not None:
-            self._update_partial_state(state, processed_image, image_data, full_upload_etag)
+            self._update_partial_state(state, processed_image, image_data, full_upload_etag if etag_committed else None)
         return processed_image
 
     async def upload_prepared_image(
@@ -1215,7 +1214,7 @@ class OpenDisplayDevice:
 
         upload_refresh_mode = RefreshMode.FULL if state is not None else refresh_mode
         full_upload_etag = _generate_etag() if state is not None else None
-        await self._dispatch_upload(
+        etag_committed = await self._dispatch_upload(
             image_data,
             upload_refresh_mode,
             compress,
@@ -1225,7 +1224,7 @@ class OpenDisplayDevice:
         )
         _LOGGER.info("Prepared image upload complete")
         if state is not None:
-            self._update_partial_state(state, processed_image, image_data, full_upload_etag)
+            self._update_partial_state(state, processed_image, image_data, full_upload_etag if etag_committed else None)
 
     async def _dispatch_upload(
         self,
@@ -1235,8 +1234,12 @@ class OpenDisplayDevice:
         compressed_data: bytes | None,
         progress_callback: Callable[[int, int], None] | None,
         new_etag: int | None = None,
-    ) -> None:
-        """Choose compressed or uncompressed upload protocol and execute it."""
+    ) -> bool:
+        """Choose compressed or uncompressed upload protocol and execute it.
+
+        Returns True if the device committed ``new_etag`` (END-with-etag was
+        sent), False if the firmware auto-completed the upload.
+        """
         display_cfg = self._config.displays[0] if (self._config and self._config.displays) else None
         supports_compression = display_cfg.supports_zip if display_cfg else True
         uses_zipxl_window = bool(display_cfg and display_cfg.supports_zipxl)
@@ -1253,7 +1256,7 @@ class OpenDisplayDevice:
                 len(compressed_data),
                 zlib_window_bits(compressed_data) or 0,
             )
-            await self._execute_upload(
+            return await self._execute_upload(
                 image_data,
                 refresh_mode,
                 use_compression=True,
@@ -1262,23 +1265,23 @@ class OpenDisplayDevice:
                 progress_callback=progress_callback,
                 new_etag=new_etag,
             )
+
+        # 4-gray ships the same two split planes (plane0 ++ plane1) over either
+        # transport; the firmware streams them to PLANE_0/PLANE_1 whether they
+        # arrive compressed or as raw 0x71 chunks, so no special-casing here.
+        if compress and not supports_compression:
+            _LOGGER.info("Device does not support compressed uploads, using uncompressed protocol")
+        elif compress and compressed_data:
+            _LOGGER.info("Compressed size exceeds %d bytes, using uncompressed protocol", MAX_COMPRESSED_SIZE)
         else:
-            # 4-gray ships the same two split planes (plane0 ++ plane1) over either
-            # transport; the firmware streams them to PLANE_0/PLANE_1 whether they
-            # arrive compressed or as raw 0x71 chunks, so no special-casing here.
-            if compress and not supports_compression:
-                _LOGGER.info("Device does not support compressed uploads, using uncompressed protocol")
-            elif compress and compressed_data:
-                _LOGGER.info("Compressed size exceeds %d bytes, using uncompressed protocol", MAX_COMPRESSED_SIZE)
-            else:
-                _LOGGER.info("Compression disabled or no compressed data, using uncompressed protocol")
-            await self._execute_upload(
-                image_data,
-                refresh_mode,
-                use_compression=False,
-                progress_callback=progress_callback,
-                new_etag=new_etag,
-            )
+            _LOGGER.info("Compression disabled or no compressed data, using uncompressed protocol")
+        return await self._execute_upload(
+            image_data,
+            refresh_mode,
+            use_compression=False,
+            progress_callback=progress_callback,
+            new_etag=new_etag,
+        )
 
     def _update_partial_state(
         self,
@@ -1287,15 +1290,23 @@ class OpenDisplayDevice:
         image_data: bytes,
         etag: int | None = None,
     ) -> None:
-        """After a successful full upload, refresh state to reflect what's now on the panel.
+        """After a full upload, refresh state to reflect what's now on the panel.
 
-        Stores the etag committed to the device on 0x72 (or generates one if
-        absent), then stashes the palette pixels for diffing on the next call.
+        ``etag`` is the etag committed to the device via END-with-etag, or None
+        if the upload auto-completed (no etag was committed). When None, the
+        device's displayed_etag was never set, so populating state.etag would
+        make the next partial attempt fail ERR_ETAG_MISMATCH (or match a stale
+        device etag and render against the wrong old plane). In that case
+        invalidate the partial state so the next upload goes full.
         ``image_data`` is unused but kept for API symmetry.
         """
         del image_data
+        if etag is None:
+            state.etag = 0
+            state.last_image = None
+            return
         palette_image = processed_image.convert("P") if processed_image.mode != "P" else processed_image
-        state.etag = _generate_etag() if etag is None else etag
+        state.etag = etag
         state.last_image = palette_image.tobytes()
         state.width, state.height = processed_image.size
         state.bytes_per_pixel = 1
@@ -1306,8 +1317,13 @@ class OpenDisplayDevice:
         stream_bytes: bytes,
         state: PartialState,
         progress_callback: Callable[[int, int], None] | None = None,
-    ) -> None:
-        """Send remaining 0x71 chunks and update upload progress."""
+    ) -> str:
+        """Send remaining 0x71 chunks and update upload progress.
+
+        Returns "success", or "fallback_full" if the device NACKed a chunk
+        before the refresh started (firmware aborts the partial on such a NACK,
+        so a subsequent full upload is safe).
+        """
         chunk_size = ENCRYPTED_CHUNK_SIZE if self._session_key is not None else CHUNK_SIZE
         total_stream_bytes = len(stream_bytes)
         bytes_sent = total_stream_bytes - len(remaining)
@@ -1319,14 +1335,20 @@ class OpenDisplayDevice:
             nack = parse_nack(ack)
             if nack is not None:
                 opcode, err = nack
+                _LOGGER.info(
+                    "Partial upload rejected mid-stream (opcode=0x%02x err=0x%02x); falling back to full upload",
+                    opcode,
+                    err,
+                )
                 state.etag = 0
                 state.last_image = None
-                raise ProtocolError(f"Partial 0x71 NACK: opcode=0x{opcode:02x} err=0x{err:02x}")
+                return "fallback_full"
             validate_ack_response(ack, CommandCode.DIRECT_WRITE_DATA)
             offset += len(chunk)
             bytes_sent += len(chunk)
             if progress_callback is not None:
                 progress_callback(bytes_sent, total_stream_bytes)
+        return "success"
 
     async def _maybe_upload_partial(
         self,
@@ -1400,6 +1422,7 @@ class OpenDisplayDevice:
 
         # Start partial upload (0x76), stream remaining 0x71 chunks, and finish
         # with partial refresh.
+        max_start = ENCRYPTED_CHUNK_SIZE if self._session_key is not None else MAX_START_PAYLOAD
         start_pkt, remaining = build_direct_write_partial_start(
             old_etag=state.etag,
             new_etag=new_etag,
@@ -1409,6 +1432,7 @@ class OpenDisplayDevice:
             width=region.rw,
             height=region.rh,
             stream_bytes=stream_bytes,
+            max_start_payload=max_start,
         )
         await self._write(start_pkt)
         try:
@@ -1416,18 +1440,25 @@ class OpenDisplayDevice:
             nack = parse_nack(response)
             if nack is not None:
                 opcode, err = nack
-                if opcode == 0x76 and err == ERR_ETAG_MISMATCH:
-                    _LOGGER.info("Partial upload: etag mismatch; falling back to full upload")
-                    state.etag = 0
-                    state.last_image = None
-                    return "fallback_full"
-                raise ProtocolError(f"Partial 0x76 NACK: opcode=0x{opcode:02x} err=0x{err:02x}")
+                # No partial data has been applied yet, so any pre-refresh 0x76
+                # NACK (etag mismatch, rect OOB/align, flags, unsupported, ...) is
+                # safe to recover from by falling back to a full upload rather than
+                # raising and losing the upload entirely.
+                _LOGGER.info(
+                    "Partial upload rejected at START (opcode=0x%02x err=0x%02x); falling back to full upload",
+                    opcode,
+                    err,
+                )
+                state.etag = 0
+                state.last_image = None
+                return "fallback_full"
             validate_ack_response(response, CommandCode.DIRECT_WRITE_PARTIAL_START)
         except (BLETimeoutError, InvalidResponseError):
             _LOGGER.info("Partial upload start was not acknowledged; falling back to full upload")
             return "fallback_full"
 
-        await self._send_partial_chunks(remaining, stream_bytes, state, progress_callback)
+        if await self._send_partial_chunks(remaining, stream_bytes, state, progress_callback) == "fallback_full":
+            return "fallback_full"
 
         await self._write(build_direct_write_end_command(RefreshMode.PARTIAL.value))
         response = await self._read(self.TIMEOUT_ACK)
@@ -1456,7 +1487,7 @@ class OpenDisplayDevice:
         uncompressed_size: int | None = None,
         progress_callback: Callable[[int, int], None] | None = None,
         new_etag: int | None = None,
-    ) -> None:
+    ) -> bool:
         """Execute image upload using compressed or uncompressed protocol.
 
         Args:
@@ -1465,6 +1496,10 @@ class OpenDisplayDevice:
             use_compression: True to use compressed protocol
             compressed_data: Compressed data (required if use_compression=True)
             uncompressed_size: Original size (required if use_compression=True)
+
+        Returns:
+            True if ``new_etag`` was committed via END-with-etag, False if the
+            firmware auto-completed the upload (no etag committed).
 
         Raises:
             ProtocolError: If upload fails
@@ -1537,6 +1572,10 @@ class OpenDisplayDevice:
         if command != CommandCode.DIRECT_WRITE_REFRESH_COMPLETE:
             raise ProtocolError(f"Unexpected response waiting for refresh: {command.name} (0x{command:04x})")
         _LOGGER.info("Display refresh complete")
+
+        # The etag is only committed on the device when we send END-with-etag;
+        # a firmware auto-END (auto_completed) never sets displayed_etag.
+        return not auto_completed and new_etag is not None
 
     async def _send_data_chunks(
         self,

--- a/src/opendisplay/partial.py
+++ b/src/opendisplay/partial.py
@@ -40,9 +40,6 @@ NACK_PREFIX = 0xFF
 # 0x76 flag bits
 PARTIAL_FLAG_COMPRESSED = 0x01  # bit 0: stream is zlib-compressed
 
-# pixels_per_byte for each bits_per_pixel value
-_PIXELS_PER_BYTE: dict[int, int] = {1: 8, 2: 4, 4: 2, 8: 1}
-
 
 def parse_nack(response: bytes) -> tuple[int, int] | None:
     """Return (opcode, error_code) if response is a 4-byte {0xFF, op, err, 0x00} NACK.
@@ -85,9 +82,11 @@ def compute_partial_region(
     if not display.partial_update_support:
         return "fallback_full"
 
-    # Firmware only supports partial refresh on 1bpp panels; 4-gray (and the
-    # 3-color schemes) are rejected, so don't attempt a doomed partial round-trip.
-    if color_scheme in (ColorScheme.BWR, ColorScheme.BWY, ColorScheme.GRAYSCALE_4):
+    # Firmware only allows partial refresh when getBitsPerPixel() == 1, i.e. MONO,
+    # and requires x/width to be multiples of 8 regardless of bpp. Every other
+    # scheme is either rejected (ERR_PARTIAL_UNSUPPORTED) or aligns to 4/2 pixels
+    # and gets ERR_RECT_ALIGN, so don't attempt a doomed partial round-trip.
+    if color_scheme != ColorScheme.MONO:
         return "fallback_full"
 
     width, height = processed_image.size
@@ -104,16 +103,8 @@ def compute_partial_region(
     if bbox is None:
         return "no_change"
 
-    bpp = {
-        ColorScheme.MONO: 1,
-        ColorScheme.BWRY: 2,
-        ColorScheme.GRAYSCALE_4: 2,
-        ColorScheme.BWGBRY: 4,
-        ColorScheme.GRAYSCALE_16: 4,
-    }.get(color_scheme, 1)
-    pixels_per_byte = _PIXELS_PER_BYTE.get(bpp, 8)
-
-    rx, ry, rw, rh = align_rect(*bbox, width, height, pixels_per_byte)
+    # MONO packs 8 pixels/byte and firmware requires 8-pixel x/width alignment.
+    rx, ry, rw, rh = align_rect(*bbox, width, height, pixels_per_byte=8)
     if rw == 0 or rh == 0:
         return "fallback_full"
 

--- a/src/opendisplay/protocol/commands.py
+++ b/src/opendisplay/protocol/commands.py
@@ -158,11 +158,14 @@ def build_direct_write_partial_start(
     width: int,
     height: int,
     stream_bytes: bytes = b"",
+    max_start_payload: int = MAX_START_PAYLOAD,
 ) -> tuple[bytes, bytes]:
     """Build 0x76 partial START packet.
 
     Fixed payload is 17 bytes; optional initial stream bytes are appended up
-    to MAX_START_PAYLOAD total packet size (including the 2-byte command).
+    to max_start_payload total packet size (including the 2-byte command). Pass
+    ENCRYPTED_CHUNK_SIZE when a session is active so the plaintext fits the
+    encrypted packet budget, mirroring build_direct_write_start_compressed.
 
     Wire fixed payload:
       flags(1) + old_etag(4BE) + new_etag(4BE) + x(2BE) + y(2BE) +
@@ -187,7 +190,7 @@ def build_direct_write_partial_start(
     )  # 1+4+4+2+2+2+2 = 17 bytes
 
     cmd = CommandCode.DIRECT_WRITE_PARTIAL_START.to_bytes(2, byteorder="big")
-    max_initial = MAX_START_PAYLOAD - 2 - len(fixed)  # 200 - 2 - 17 = 181 bytes
+    max_initial = max_start_payload - 2 - len(fixed)  # e.g. 200 - 2 - 17 = 181 bytes
     initial = stream_bytes[:max_initial]
     remaining = stream_bytes[max_initial:]
     return cmd + fixed + initial, remaining

--- a/tests/unit/test_device_partial.py
+++ b/tests/unit/test_device_partial.py
@@ -137,10 +137,11 @@ def test_empty_state_falls_back_to_full(monkeypatch):
     full_uploads = 0
     refresh_modes: list[RefreshMode] = []
 
-    async def execute_upload(image_data, refresh_mode, **kwargs) -> None:
+    async def execute_upload(image_data, refresh_mode, **kwargs) -> bool:
         nonlocal full_uploads
         full_uploads += 1
         refresh_modes.append(refresh_mode)
+        return True  # etag committed (END-with-etag sent)
 
     monkeypatch.setattr(device, "_execute_upload", execute_upload)
 
@@ -152,6 +153,23 @@ def test_empty_state_falls_back_to_full(monkeypatch):
     assert refresh_modes == [RefreshMode.FULL]
     assert state.etag != 0
     assert state.last_image == _image().tobytes()
+
+
+def test_auto_completed_full_upload_does_not_commit_etag(monkeypatch):
+    """If the firmware auto-completes the upload (no END-with-etag), partial
+    state must be invalidated rather than storing an uncommitted etag (M2)."""
+    device = _device()
+    state = PartialState()
+
+    async def execute_upload(image_data, refresh_mode, **kwargs) -> bool:
+        return False  # firmware auto-completed; etag not committed
+
+    monkeypatch.setattr(device, "_execute_upload", execute_upload)
+
+    asyncio.run(device.upload_prepared_image((b"\x00" * 16, None, _image()), state=state))
+
+    assert state.etag == 0
+    assert state.last_image is None
 
 
 def test_etag_mismatch_clears_state_and_retries_full_once(monkeypatch):
@@ -166,10 +184,11 @@ def test_etag_mismatch_clears_state_and_retries_full_once(monkeypatch):
     async def read_response(timeout: float) -> bytes:
         return bytes([0xFF, 0x76, ERR_ETAG_MISMATCH, 0x00])
 
-    async def execute_upload(image_data, refresh_mode, **kwargs) -> None:
+    async def execute_upload(image_data, refresh_mode, **kwargs) -> bool:
         nonlocal full_uploads
         full_uploads += 1
         refresh_modes.append(refresh_mode)
+        return True  # etag committed (END-with-etag sent)
 
     monkeypatch.setattr(device, "_write", capture_write)
     monkeypatch.setattr(device, "_read", read_response)
@@ -181,6 +200,60 @@ def test_etag_mismatch_clears_state_and_retries_full_once(monkeypatch):
     assert refresh_modes == [RefreshMode.FULL]
     assert state.etag != 0
     assert state.last_image == _image(changed=True).tobytes()
+
+
+def test_non_etag_start_nack_falls_back_to_full(monkeypatch):
+    """Any pre-refresh 0x76 NACK (not just etag mismatch) must fall back to a
+    full upload rather than raising ProtocolError (M1)."""
+    from opendisplay.partial import ERR_RECT_ALIGN
+
+    device = _device()
+    state = PartialState(etag=0x01020304, last_image=_image().tobytes(), width=16, height=8, bytes_per_pixel=1)
+    full_uploads = 0
+
+    async def capture_write(data: bytes) -> None:
+        pass
+
+    async def read_response(timeout: float) -> bytes:
+        return bytes([0xFF, 0x76, ERR_RECT_ALIGN, 0x00])
+
+    async def execute_upload(image_data, refresh_mode, **kwargs) -> bool:
+        nonlocal full_uploads
+        full_uploads += 1
+        return True
+
+    monkeypatch.setattr(device, "_write", capture_write)
+    monkeypatch.setattr(device, "_read", read_response)
+    monkeypatch.setattr(device, "_execute_upload", execute_upload)
+
+    # Must not raise; must fall back to a single full upload.
+    asyncio.run(device.upload_prepared_image((b"\x00" * 16, None, _image(changed=True)), state=state))
+
+    assert full_uploads == 1
+
+
+def test_non_mono_scheme_never_attempts_partial(monkeypatch):
+    """Only MONO panels may attempt a partial update (M1)."""
+    from opendisplay.partial import compute_partial_region
+
+    state = PartialState(etag=0x01, last_image=_image().tobytes(), width=16, height=8, bytes_per_pixel=1)
+    for scheme in (ColorScheme.BWRY, ColorScheme.BWGBRY, ColorScheme.GRAYSCALE_16, ColorScheme.GRAYSCALE_4):
+        result = compute_partial_region(_image(changed=True), state, _config(), scheme)
+        assert result == "fallback_full"
+
+
+def test_partial_start_respects_encrypted_payload_budget():
+    """Encrypted partial START must cap its inline payload at the encrypted
+    packet budget, like the compressed START (M10)."""
+    from opendisplay.protocol.commands import ENCRYPTED_CHUNK_SIZE, build_direct_write_partial_start
+
+    stream = b"\xab" * 500
+    pkt_default, _ = build_direct_write_partial_start(0, 1, 0, 0, 0, 8, 8, stream_bytes=stream)
+    pkt_enc, rem_enc = build_direct_write_partial_start(
+        0, 1, 0, 0, 0, 8, 8, stream_bytes=stream, max_start_payload=ENCRYPTED_CHUNK_SIZE
+    )
+    assert len(pkt_enc) <= ENCRYPTED_CHUNK_SIZE
+    assert len(pkt_enc) < len(pkt_default)
 
 
 def test_partial_request_uses_partial_even_when_full_compressed_is_smaller(monkeypatch):


### PR DESCRIPTION
## Summary

Three related partial-update correctness fixes.

### M1 — partial only where firmware allows it, and fall back instead of aborting (🟠)
Firmware only allows partial refresh when `getBitsPerPixel() == 1` (MONO) and requires x/width multiples of **8**. Previously BWRY/BWGBRY/GRAYSCALE_16 proceeded and aligned to 4/2 pixels, guaranteeing `ERR_RECT_ALIGN`/`ERR_PARTIAL_UNSUPPORTED`; and every non-etag NACK raised `ProtocolError`, losing the upload.

- `compute_partial_region` now restricts to `ColorScheme.MONO` and aligns to 8 pixels.
- Every pre-refresh `0x76`/`0x71` NACK is treated as fallback-to-full (firmware aborts the partial on such a NACK, so a full upload is safe).

### M2 — don't commit an etag the device never stored (🟠)
The etag is only committed via END-with-etag, skipped when the firmware auto-completes. Previously `PartialState.etag` was populated unconditionally → uncompressed-only devices got permanent `ERR_ETAG_MISMATCH` fallback, and a stale etag could render against the wrong old plane. `_execute_upload`/`_dispatch_upload` now report whether the etag was committed; state stores it only then, otherwise invalidates so the next upload goes full.

### M10 — respect the encrypted payload budget on partial START (🟠)
`build_direct_write_partial_start` now takes `max_start_payload`, threaded with `ENCRYPTED_CHUNK_SIZE` when a session is active (like the compressed START), instead of the 200-byte default that could overflow the ~185-byte encrypted envelope.

## Test plan
- [x] `uv run pytest -q` → 443 passed (new + two updated tests)
- [x] `ruff`, `mypy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)