### PR TITLE
fix: preserve real config data through JSON export/import (M7)

### DIFF
--- a/src/opendisplay/models/config_json.py
+++ b/src/opendisplay/models/config_json.py
@@ -45,6 +45,26 @@ def _parse_int(value: str | int) -> int:
     return int(value)
 
 
+def _hex_bytes(value: bytes) -> str:
+    """Encode raw bytes as a ``0x``-prefixed hex string for JSON export."""
+    return "0x" + value.hex()
+
+
+def _parse_hex_bytes(value: str | int, size: int) -> bytes:
+    """Parse a hex blob (or legacy ``0x0`` scalar) into ``size`` bytes.
+
+    Preserves per-byte data across a JSON round-trip (unlike parsing to an int,
+    which drops leading zero bytes). Truncates or zero-pads to exactly ``size``.
+    """
+    text = str(value).strip()
+    if text.lower().startswith("0x"):
+        text = text[2:]
+    if len(text) % 2:  # odd nibble count (e.g. legacy "0x0")
+        text = "0" + text
+    raw = bytes.fromhex(text) if text else b""
+    return raw[:size].ljust(size, b"\x00")
+
+
 def config_to_json(config: GlobalConfig) -> dict[str, Any]:
     """Export GlobalConfig to JSON-serializable dict.
 
@@ -150,15 +170,16 @@ def config_to_json(config: GlobalConfig) -> dict[str, Any]:
                     "color_scheme": str(display.color_scheme),
                     "transmission_modes": f"0x{display.transmission_modes:x}",
                     "clk_pin": f"0x{display.clk_pin:x}",
-                    "reserved_pin_2": "0x0",
-                    "reserved_pin_3": "0x0",
-                    "reserved_pin_4": "0x0",
-                    "reserved_pin_5": "0x0",
-                    "reserved_pin_6": "0x0",
-                    "reserved_pin_7": "0x0",
-                    "reserved_pin_8": "0x0",
-                    "full_update_mC": "0x0",
-                    "reserved": "0x0",
+                    # reserved_pins holds GPIO pins 2-8 (7 bytes); export the real
+                    # values so a JSON round-trip does not zero real hardware pins.
+                    **{
+                        f"reserved_pin_{i + 2}": f"0x{display.reserved_pins[i]:x}"
+                        if i < len(display.reserved_pins)
+                        else "0x0"
+                        for i in range(7)
+                    },
+                    "full_update_mC": f"0x{display.full_update_mC:x}",
+                    "reserved": _hex_bytes(display.reserved),
                 },
             }
         )
@@ -234,12 +255,21 @@ def config_to_json(config: GlobalConfig) -> dict[str, Any]:
                     "instance_number": f"0x{binary_input.instance_number:x}",
                     "input_type": str(binary_input.input_type),
                     "display_as": str(binary_input.display_as),
+                    # 8 GPIO reserved pins; export the real values.
+                    **{
+                        f"reserved_pin_{i + 1}": f"0x{binary_input.reserved_pins[i]:x}"
+                        if i < len(binary_input.reserved_pins)
+                        else "0x0"
+                        for i in range(8)
+                    },
                     "input_flags": f"0x{binary_input.input_flags:x}",
                     "invert": f"0x{binary_input.invert:x}",
                     "pullups": f"0x{binary_input.pullups:x}",
                     "pulldowns": f"0x{binary_input.pulldowns:x}",
                     "button_data_byte_index": f"0x{binary_input.button_data_byte_index:x}",
-                    "reserved": "0x0",
+                    # reserved holds ADC-ladder thresholds + power_off_flags/hold;
+                    # export the raw blob so a round-trip preserves them.
+                    "reserved": _hex_bytes(binary_input.reserved),
                 },
             }
         )
@@ -500,9 +530,9 @@ def config_from_json(data: dict[str, Any]) -> GlobalConfig:
                     color_scheme=_parse_int(fields.get("color_scheme", "0")),
                     transmission_modes=_parse_int(fields.get("transmission_modes", "0")),
                     clk_pin=_parse_int(fields.get("clk_pin", "0xff")),
-                    reserved_pins=bytes(7),  # Fixed size
+                    reserved_pins=bytes(_parse_int(fields.get(f"reserved_pin_{i}", "0")) & 0xFF for i in range(2, 9)),
                     full_update_mC=_parse_int(fields.get("full_update_mC", "0")),
-                    reserved=bytes(13),  # Fixed size
+                    reserved=_parse_hex_bytes(fields.get("reserved", "0x0"), 13),
                 )
             )
 
@@ -558,13 +588,13 @@ def config_from_json(data: dict[str, Any]) -> GlobalConfig:
                     instance_number=_parse_int(fields.get("instance_number", "0")),
                     input_type=_parse_int(fields.get("input_type", "0")),
                     display_as=_parse_int(fields.get("display_as", "0")),
-                    reserved_pins=bytes(8),  # Fixed size
+                    reserved_pins=bytes(_parse_int(fields.get(f"reserved_pin_{i}", "0")) & 0xFF for i in range(1, 9)),
                     input_flags=_parse_int(fields.get("input_flags", "0")),
                     invert=_parse_int(fields.get("invert", "0")),
                     pullups=_parse_int(fields.get("pullups", "0")),
                     pulldowns=_parse_int(fields.get("pulldowns", "0")),
                     button_data_byte_index=_parse_int(fields.get("button_data_byte_index", "0")),
-                    reserved=bytes(14),  # Fixed size
+                    reserved=_parse_hex_bytes(fields.get("reserved", "0x0"), 14),
                 )
             )
 

--- a/tests/unit/test_config_json_roundtrip.py
+++ b/tests/unit/test_config_json_roundtrip.py
@@ -1,0 +1,109 @@
+"""Round-trip tests for config JSON export/import (M7).
+
+Real hardware pins and reserved-blob fields (ADC thresholds, power_off flags)
+must survive a binary -> JSON -> binary round-trip instead of being zeroed.
+"""
+
+from __future__ import annotations
+
+from opendisplay.models.config import (
+    BinaryInputs,
+    DisplayConfig,
+    GlobalConfig,
+    ManufacturerData,
+    PowerOption,
+    SystemConfig,
+)
+from opendisplay.models.config_json import config_from_json, config_to_json
+
+
+def _base_config(**overrides) -> GlobalConfig:
+    return GlobalConfig(
+        system=SystemConfig(ic_type=0, communication_modes=0, device_flags=0, pwr_pin=0xFF, reserved=b"\x00" * 15),
+        manufacturer=ManufacturerData(manufacturer_id=0, board_type=0, board_revision=0, reserved=b"\x00" * 6),
+        power=PowerOption(
+            power_mode=0,
+            battery_capacity_mah=b"\x00\x00\x00",
+            sleep_timeout_ms=0,
+            tx_power=0,
+            sleep_flags=0,
+            battery_sense_pin=0xFF,
+            battery_sense_enable_pin=0xFF,
+            battery_sense_flags=0,
+            capacity_estimator=0,
+            voltage_scaling_factor=0,
+            deep_sleep_current_ua=0,
+            deep_sleep_time_seconds=0,
+            reserved=b"\x00" * 10,
+        ),
+        **overrides,
+    )
+
+
+def _display() -> DisplayConfig:
+    return DisplayConfig(
+        instance_number=0,
+        display_technology=0,
+        panel_ic_type=1,
+        pixel_width=100,
+        pixel_height=100,
+        active_width_mm=10,
+        active_height_mm=10,
+        tag_type=0,
+        rotation=0,
+        reset_pin=1,
+        busy_pin=2,
+        dc_pin=3,
+        cs_pin=4,
+        data_pin=5,
+        partial_update_support=0,
+        color_scheme=0,
+        transmission_modes=0,
+        clk_pin=6,
+        reserved_pins=bytes([11, 12, 13, 14, 15, 16, 17]),
+        full_update_mC=1234,
+        reserved=bytes(range(13)),
+    )
+
+
+def _binary_input() -> BinaryInputs:
+    return BinaryInputs(
+        instance_number=0,
+        input_type=1,
+        display_as=2,
+        reserved_pins=bytes([21, 22, 23, 24, 25, 26, 27, 28]),
+        input_flags=3,
+        invert=0,
+        pullups=1,
+        pulldowns=0,
+        button_data_byte_index=4,
+        reserved=bytes(range(14)),
+    )
+
+
+def test_display_pins_full_update_and_reserved_survive_json_roundtrip() -> None:
+    cfg = _base_config(displays=[_display()])
+    back = config_from_json(config_to_json(cfg))
+    d = back.displays[0]
+    assert d.reserved_pins == bytes([11, 12, 13, 14, 15, 16, 17])
+    assert d.full_update_mC == 1234
+    assert d.reserved == bytes(range(13))
+
+
+def test_binary_input_pins_and_reserved_survive_json_roundtrip() -> None:
+    cfg = _base_config(displays=[_display()], binary_inputs=[_binary_input()])
+    back = config_from_json(config_to_json(cfg))
+    b = back.binary_inputs[0]
+    assert b.reserved_pins == bytes([21, 22, 23, 24, 25, 26, 27, 28])
+    assert b.reserved == bytes(range(14))  # ADC thresholds / power_off blob preserved
+
+
+def test_legacy_zero_reserved_still_parses() -> None:
+    """A legacy JSON with reserved="0x0" must still import as zero bytes."""
+    cfg = _base_config(displays=[_display()])
+    data = config_to_json(cfg)
+    for packet in data["packets"]:
+        if packet["name"] == "display":
+            packet["fields"]["reserved"] = "0x0"
+    back = config_from_json(data)
+    assert back.displays[0].reserved == bytes(13)


### PR DESCRIPTION
## Summary

### M7 — JSON export silently zeroed real config data (🟠)
`config_to_json` hardcoded display `full_update_mC` and `reserved_pin_2..8` to `"0x0"`, and the `binary_input` export omitted the 8 GPIO `reserved_pins` and the `reserved` blob (which carries the ADC-ladder thresholds and `power_off_flags`/`power_off_hold_sec`). So a **binary → JSON → binary round-trip written back to a device silently zeroed real hardware pins** and firmware fields.

## Fix

- Export the real `reserved_pins` (as `reserved_pin_N`) and `full_update_mC`.
- Export the `reserved` blobs as hex (new `_hex_bytes`) so fields living inside them (ADC thresholds, power-off) survive without being individually modeled.
- Import reconstructs `reserved_pins` from the per-pin fields and parses the reserved blob via `_parse_hex_bytes`, which stays **backward compatible** with legacy `"0x0"` values (parsed as all-zero bytes).

## Test plan

- [x] `uv run pytest -q` → 446 passed (3 new: display pins/full_update_mC/reserved survive round-trip, binary_input pins + reserved blob survive, legacy `"0x0"` still parses as zeros)
- [x] `ruff`, `mypy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)