### PR TITLE
feat: warn about firmware upload limitations for BWR/BWY and non-aligned widths (C1/C2)

### DIFF
--- a/src/opendisplay/device.py
+++ b/src/opendisplay/device.py
@@ -148,6 +148,47 @@ def _capabilities_from_config(config: GlobalConfig) -> DeviceCapabilities:
     )
 
 
+# pixels-per-byte for each direct-write color scheme. GRAYSCALE_4 is omitted:
+# firmware row-pads its upload, so a non-aligned width is safe there.
+_DIRECT_WRITE_PIXELS_PER_BYTE: dict[ColorScheme, int] = {
+    ColorScheme.MONO: 8,
+    ColorScheme.BWR: 8,
+    ColorScheme.BWY: 8,
+    ColorScheme.BWRY: 4,
+    ColorScheme.BWGBRY: 2,
+    ColorScheme.GRAYSCALE_16: 2,
+}
+
+
+def _warn_firmware_upload_limitations(color_scheme: ColorScheme, width: int) -> None:
+    """Warn about known device-firmware upload bugs the library can't fix on-device.
+
+    - BWR/BWY direct write drops the red/yellow plane on current firmware (C1).
+    - Widths not aligned to the scheme's byte boundary are truncated because the
+      firmware sizes the upload from the raw pixel count (C2). GRAYSCALE_4 is
+      exempt because firmware row-pads it.
+    """
+    if color_scheme in (ColorScheme.BWR, ColorScheme.BWY):
+        _LOGGER.warning(
+            "Color scheme %s (BWR/BWY direct write) is not reliably supported by current "
+            "firmware: it stores only one plane, so the red/yellow layer is discarded and "
+            "the black/white layer renders over stale color RAM. Output may be wrong until "
+            "device firmware gains BWR/BWY parity.",
+            color_scheme.name,
+        )
+
+    ppb = _DIRECT_WRITE_PIXELS_PER_BYTE.get(color_scheme)
+    if ppb is not None and width % ppb != 0:
+        _LOGGER.warning(
+            "Panel width %d is not a multiple of %d for color scheme %s; current firmware "
+            "sizes the upload from the raw pixel count and will truncate the last rows on "
+            "the device. A byte-aligned width avoids this.",
+            width,
+            ppb,
+            color_scheme.name,
+        )
+
+
 def prepare_image(
     image: Image.Image,
     config: GlobalConfig | None = None,
@@ -228,6 +269,8 @@ def prepare_image(
             "Panel IC 0x%04x is not a known 4-gray panel. GRAYSCALE_4 encoding may not display correctly.",
             panel_ic_type,
         )
+
+    _warn_firmware_upload_limitations(color_scheme, capabilities.width)
 
     palette = get_palette_for_display(panel_ic_type, color_scheme, use_measured_palettes)
     dithered = dither_image(

--- a/tests/unit/test_firmware_limitation_warnings.py
+++ b/tests/unit/test_firmware_limitation_warnings.py
@@ -1,0 +1,45 @@
+"""Tests for firmware-limitation warnings on upload prep (C1/C2 mitigations)."""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+from epaper_dithering import ColorScheme
+
+from opendisplay.device import _warn_firmware_upload_limitations
+
+
+def _messages(caplog: pytest.LogCaptureFixture) -> list[str]:
+    return [r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING]
+
+
+def test_bwr_warns_about_lost_color_plane(caplog: pytest.LogCaptureFixture) -> None:
+    with caplog.at_level(logging.WARNING):
+        _warn_firmware_upload_limitations(ColorScheme.BWR, 800)
+    assert any("red/yellow" in m for m in _messages(caplog))
+
+
+def test_bwy_warns_about_lost_color_plane(caplog: pytest.LogCaptureFixture) -> None:
+    with caplog.at_level(logging.WARNING):
+        _warn_firmware_upload_limitations(ColorScheme.BWY, 800)
+    assert any("red/yellow" in m for m in _messages(caplog))
+
+
+def test_non_byte_aligned_mono_width_warns(caplog: pytest.LogCaptureFixture) -> None:
+    with caplog.at_level(logging.WARNING):
+        _warn_firmware_upload_limitations(ColorScheme.MONO, 122)  # 122 % 8 != 0
+    assert any("truncate" in m for m in _messages(caplog))
+
+
+def test_aligned_mono_width_does_not_warn(caplog: pytest.LogCaptureFixture) -> None:
+    with caplog.at_level(logging.WARNING):
+        _warn_firmware_upload_limitations(ColorScheme.MONO, 800)
+    assert _messages(caplog) == []
+
+
+def test_grayscale4_non_aligned_width_is_exempt(caplog: pytest.LogCaptureFixture) -> None:
+    # firmware row-pads the 4-gray path, so a non-aligned width is safe there.
+    with caplog.at_level(logging.WARNING):
+        _warn_firmware_upload_limitations(ColorScheme.GRAYSCALE_4, 122)
+    assert _messages(caplog) == []


### PR DESCRIPTION
## Summary

C1 and C2 are **device-firmware** bugs the library cannot fix on-device — but it *can* surface them loudly instead of walking into them silently. This PR adds warnings at image-prep time (the shared `prepare_image` path, so both `upload_image` and standalone `prepare_image` callers get them).

### C1 — BWR/BWY direct write is broken end-to-end (🔴 [FW])
Firmware sets `directWriteTotalBytes` for a single plane and never switches to `PLANE_1`, so the red/yellow plane is discarded and the black/white layer renders over stale color RAM — with no error surfaced. We now warn whenever the scheme is BWR/BWY.

### C2 — non-byte-aligned widths silently truncate the last rows (🔴 [FW])
Firmware sizes the upload from the raw pixel count (`(w*h+7)/8`) while the library row-pads to the panel pitch. On widths not divisible by 8 (1bpp), 4 (2bpp) or 2 (4bpp), the device auto-ENDs early and never writes the last rows. We warn when the panel width isn't aligned for the scheme. **GRAYSCALE_4 is exempt** — firmware row-pads that path.

These are non-breaking (log-only) mitigations; the real fix is in device firmware.

## Test plan

- [x] `uv run pytest -q` → 448 passed (5 new: BWR/BWY warn, non-aligned MONO warns, aligned MONO silent, GRAYSCALE_4 exempt)
- [x] `ruff`, `mypy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)