### PR TITLE
fix: surface device error frames with typed exceptions (§4)

### DIFF
--- a/src/opendisplay/device.py
+++ b/src/opendisplay/device.py
@@ -689,6 +689,13 @@ class OpenDisplayDevice:
 
         # Read first chunk
         response = await self._read(self.TIMEOUT_FIRST_CHUNK)
+
+        # Firmware answers a device-with-no-config with the 4-byte error frame
+        # {0xFF, 0x40, 0x00, 0x00}. Without this check the {0x00,0x00} length
+        # field is misread as a zero-length config instead of "no config".
+        if len(response) == 4 and response[0] == 0xFF and response[1] == CommandCode.READ_CONFIG:
+            raise ProtocolError("Device has no stored configuration (READ_CONFIG returned an error frame)")
+
         chunk_data = strip_command_echo(response, CommandCode.READ_CONFIG)
 
         # Parse first chunk header

--- a/src/opendisplay/protocol/responses.py
+++ b/src/opendisplay/protocol/responses.py
@@ -33,7 +33,12 @@ def unpack_command_code(data: bytes, offset: int = 0) -> int:
 
     Returns:
         Command code as integer
+
+    Raises:
+        InvalidResponseError: If fewer than 2 bytes are available at ``offset``.
     """
+    if len(data) < offset + 2:
+        raise InvalidResponseError(f"Response too short for a command code: {len(data)} bytes at offset {offset}")
     return int(struct.unpack(">H", data[offset : offset + 2])[0])
 
 
@@ -70,7 +75,14 @@ def check_response_type(response: bytes) -> tuple[CommandCode, bool]:
     """
     code = unpack_command_code(response)
     is_ack = bool(code & RESPONSE_HIGH_BIT_FLAG)
-    command = CommandCode(code & ~RESPONSE_HIGH_BIT_FLAG)
+    raw = code & ~RESPONSE_HIGH_BIT_FLAG
+    try:
+        command = CommandCode(raw)
+    except ValueError as e:
+        # Firmware error frames (e.g. {0xFF,0xFF} compressed-failure, 4-byte
+        # NACKs) carry codes that aren't in CommandCode; surface a typed protocol
+        # error instead of a bare ValueError so upload loops can handle it.
+        raise InvalidResponseError(f"Unknown command code in response: 0x{raw:04x}") from e
     return command, is_ack
 
 

--- a/tests/unit/test_protocol_error_frames.py
+++ b/tests/unit/test_protocol_error_frames.py
@@ -1,0 +1,46 @@
+"""Tests for graceful handling of device error frames (§4 minor)."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from epaper_dithering import ColorScheme
+
+from opendisplay import OpenDisplayDevice
+from opendisplay.exceptions import InvalidResponseError, ProtocolError
+from opendisplay.models.capabilities import DeviceCapabilities
+from opendisplay.protocol.responses import check_response_type, unpack_command_code
+
+
+def test_unpack_command_code_short_raises_invalid_response() -> None:
+    with pytest.raises(InvalidResponseError):
+        unpack_command_code(b"\x00")
+
+
+def test_check_response_type_unknown_code_raises_invalid_response() -> None:
+    # {0xFF, 0xFF} is the firmware compressed-failure frame; not a CommandCode.
+    with pytest.raises(InvalidResponseError):
+        check_response_type(b"\xff\xff")
+
+
+class _FakeConn:
+    def __init__(self, responses: list[bytes]) -> None:
+        self._responses = responses
+
+    async def write_command(self, data: bytes) -> None:
+        pass
+
+    async def read_response(self, timeout: float) -> bytes:
+        return self._responses.pop(0)
+
+
+def test_interrogate_reports_no_config_error_frame() -> None:
+    device = OpenDisplayDevice(
+        mac_address="AA:BB:CC:DD:EE:FF",
+        capabilities=DeviceCapabilities(width=2, height=2, color_scheme=ColorScheme.MONO),
+    )
+    device._connection = _FakeConn([b"\xff\x40\x00\x00"])  # type: ignore[assignment]
+
+    with pytest.raises(ProtocolError, match="no stored configuration"):
+        asyncio.run(device.interrogate())


### PR DESCRIPTION
## Summary

Two §4-minor fixes for graceful handling of firmware error frames.

- **`unpack_command_code` / `check_response_type`** raised a bare `struct.error` on `<2`-byte frames and a `ValueError` on unknown command codes. The firmware's 2-byte `{0xFF,0xFF}` compressed-failure frame and 4-byte NACKs hit exactly this in the upload loop, crashing with the wrong exception type. Both are now wrapped in `InvalidResponseError`.
- **`interrogate()`** misread the READ_CONFIG "no config" error frame `{0xFF,0x40,0x00,0x00}` as a *zero-length* config (its `0x0000` length field). It now detects that frame and raises a clear `ProtocolError`.

## Test plan

- [x] `uv run pytest -q` → 446 passed (3 new: short frame → InvalidResponseError, unknown code `{0xFF,0xFF}` → InvalidResponseError, interrogate no-config frame → ProtocolError)
- [x] `ruff`, `mypy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)