### PR TITLE
fix: minor model/encoding validation (§4)

### DIFF
--- a/src/opendisplay/encoding/images.py
+++ b/src/opendisplay/encoding/images.py
@@ -88,7 +88,12 @@ def encode_image(
         # Palette indices 0-5 map to firmware values 0,1,2,3,5,6 (4 is skipped!)
         return encode_4bpp(image, bwgbry_mapping=True)
     if color_scheme == ColorScheme.GRAYSCALE_4:
-        return encode_2bpp(image)
+        # 4-gray needs two 1-bit controller planes, not packed 2bpp; the packed
+        # form is not accepted by any firmware path. prepare_image routes 4-gray
+        # through encode_gray4_bitplanes() instead.
+        raise ValueError(
+            f"Color scheme {color_scheme.name} requires two 1-bit planes, use encode_gray4_bitplanes() instead"
+        )
     if color_scheme == ColorScheme.GRAYSCALE_16:
         # 16-level grayscale uses 4bpp; palette indices 0-15 map directly (0=black, 15=white)
         return encode_4bpp(image)

--- a/src/opendisplay/models/advertisement.py
+++ b/src/opendisplay/models/advertisement.py
@@ -94,6 +94,10 @@ class AdvertisementData:
         """
         if self.format_version != "v1":
             return None
+        # Valid start offsets are 0-6 within the 11-byte block; a negative value
+        # would index from the end and return garbage.
+        if not 0 <= start_byte <= 6:
+            return None
         if start_byte + 5 > len(self.dynamic_data):
             return None
         byte0 = self.dynamic_data[start_byte]

--- a/src/opendisplay/models/buzzer_activate.py
+++ b/src/opendisplay/models/buzzer_activate.py
@@ -1,4 +1,4 @@
-"""Typed buzzer activation config for firmware command 0x0075."""
+"""Typed buzzer activation config for firmware command 0x0077."""
 
 from __future__ import annotations
 
@@ -43,7 +43,7 @@ class BuzzerPattern:
 
 @dataclass(frozen=True, slots=True)
 class BuzzerActivateConfig:
-    """Full buzzer activation payload for command 0x0075."""
+    """Full buzzer activation payload for command 0x0077."""
 
     patterns: tuple[BuzzerPattern, ...]
     outer_repeats: int = 1  # 1–255

--- a/src/opendisplay/models/enums.py
+++ b/src/opendisplay/models/enums.py
@@ -163,6 +163,7 @@ class SensorType(IntEnum):
     HUMIDITY = 2
     AXP2101_PMIC = 3
     SHT40 = 4
+    BQ27220 = 5
 
 
 class WifiEncryption(IntEnum):

--- a/tests/unit/test_minor_model_validation.py
+++ b/tests/unit/test_minor_model_validation.py
@@ -1,0 +1,32 @@
+"""Minor model/encoding validation fixes (§4)."""
+
+from __future__ import annotations
+
+import pytest
+from epaper_dithering import ColorScheme
+from PIL import Image
+
+from opendisplay.encoding.images import encode_image
+from opendisplay.models.advertisement import parse_advertisement
+from opendisplay.models.enums import SensorType
+
+
+def test_sensor_type_has_bq27220() -> None:
+    assert SensorType.BQ27220 == 5
+
+
+def test_encode_image_grayscale4_raises() -> None:
+    img = Image.new("P", (4, 2))
+    with pytest.raises(ValueError, match="two 1-bit planes"):
+        encode_image(img, ColorScheme.GRAYSCALE_4)
+
+
+def test_touch_event_rejects_negative_start_byte() -> None:
+    # v1 advertisement (14 bytes: 11 dynamic + temp + battery + status)
+    data = bytes([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 0x7C, 0x8B, 0x53])
+    adv = parse_advertisement(data)
+    assert adv.format_version == "v1"
+
+    assert adv.touch_event(-1) is None  # would index from the end -> garbage
+    assert adv.touch_event(7) is None  # past the valid 0-6 range
+    assert adv.touch_event(0) is not None  # valid offset still works


### PR DESCRIPTION
## Summary

A batch of small, self-contained §4-minor correctness fixes.

- **`SensorType.BQ27220 = 5`** — was missing, so the value degraded to a raw int.
- **`AdvertisementData.touch_event`** now rejects a negative or `>6` `start_byte`. A negative offset previously indexed from the end of the block and returned garbage; the firmware-valid range is 0–6.
- **`encode_image(GRAYSCALE_4)`** now raises instead of returning packed 2bpp that **no firmware path accepts** — 4-gray needs two 1-bit controller planes (`prepare_image` already routes it through `encode_gray4_bitplanes()`). Mirrors the existing BWR/BWY guard.
- **Buzzer docstrings** now cite command `0x0077` (the actual buzzer code; `0x0075` is LED STOP). Wire bytes were already correct.

## Test plan

- [x] `uv run pytest -q` → 446 passed (3 new: `BQ27220 == 5`, `encode_image(GRAYSCALE_4)` raises, `touch_event` rejects out-of-range offsets)
- [x] `ruff`, `mypy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)