### PR TITLE
fix: carry across octets when computing the nRF DFU MAC (+1) (§4)

### DIFF
--- a/src/opendisplay/ota.py
+++ b/src/opendisplay/ota.py
@@ -8,6 +8,20 @@ from typing import TYPE_CHECKING
 
 from .exceptions import OTAError
 
+
+def _increment_mac(address: str) -> str:
+    """Return the BLE MAC address incremented by 1, carrying across octets.
+
+    The nRF DFU bootloader advertises at ``original + 1``. Incrementing only the
+    last octet (``+1 & 0xFF``) fails to carry when it is 0xFF (e.g. ...:FF -> ...:00
+    instead of rolling into the previous octet), causing a silent 30 s scan miss.
+    """
+    parts = address.upper().split(":")
+    mac_int = int("".join(parts), 16)
+    mac_int = (mac_int + 1) & 0xFFFFFFFFFFFF
+    return ":".join(f"{(mac_int >> (8 * (5 - i))) & 0xFF:02X}" for i in range(6))
+
+
 if TYPE_CHECKING:
     from bleak.backends.device import BLEDevice
 
@@ -180,8 +194,7 @@ async def find_nrf_dfu_device(original_address: str) -> BLEDevice | None:
     """
     from bleak import BleakScanner
 
-    parts = original_address.upper().split(":")
-    mac_plus1 = ":".join(parts[:-1] + [f"{(int(parts[-1], 16) + 1) & 0xFF:02X}"])
+    mac_plus1 = _increment_mac(original_address)
 
     for attempt in range(15):  # 2 s × 15 = 30 s
         await asyncio.sleep(2.0)

--- a/tests/unit/test_ota.py
+++ b/tests/unit/test_ota.py
@@ -86,8 +86,8 @@ async def test_find_nrf_dfu_device_not_found_returns_none() -> None:
 
 @pytest.mark.asyncio
 async def test_find_nrf_dfu_device_mac_plus1_wraps_ff() -> None:
-    """MAC+1 wraps correctly: EE:FF → EE:00."""
-    dfu_dev = _make_scanner_device("AA:BB:CC:DD:EE:00")
+    """MAC+1 carries across octets: EE:FF → EF:00 (not EE:00)."""
+    dfu_dev = _make_scanner_device("AA:BB:CC:DD:EF:00")
 
     with (
         patch("opendisplay.ota.asyncio.sleep", new=AsyncMock()),

--- a/tests/unit/test_ota_mac_increment.py
+++ b/tests/unit/test_ota_mac_increment.py
@@ -1,0 +1,20 @@
+"""Test nRF DFU MAC increment carries across octets (§4)."""
+
+from __future__ import annotations
+
+import pytest
+
+from opendisplay.ota import _increment_mac
+
+
+@pytest.mark.parametrize(
+    ("addr", "expected"),
+    [
+        ("AA:BB:CC:DD:EE:01", "AA:BB:CC:DD:EE:02"),
+        ("AA:BB:CC:DD:EE:FF", "AA:BB:CC:DD:EF:00"),  # carry into previous octet
+        ("AA:BB:CC:DD:FF:FF", "AA:BB:CC:DE:00:00"),  # double carry
+        ("FF:FF:FF:FF:FF:FF", "00:00:00:00:00:00"),  # wraps around
+    ],
+)
+def test_increment_mac_carries(addr: str, expected: str) -> None:
+    assert _increment_mac(addr) == expected


### PR DESCRIPTION
## Summary

### `find_nrf_dfu_device` MAC+1 wrapped without carry (🟡)
The nRF DFU bootloader advertises at `original_address + 1`. The code incremented only the **last octet** with `(+1) & 0xFF`, so an address ending in `0xFF` became `…:EE:00` instead of carrying into the previous octet (`…:EF:00`). The bootloader then advertised at an address the scanner never matched → a silent 30 s scan failure on those devices.

## Fix

Increment the full 48-bit address with carry, extracted into a small, tested `_increment_mac` helper.

## Test plan

- [x] `uv run pytest -q` → 447 passed (new parametrized carry test: `…EE:01→…EE:02`, `…EE:FF→…EF:00`, `…FF:FF→…DE:00:00`… wait double-carry, `FF:…FF→00:…00`; updated an existing test that encoded the old no-carry behavior)
- [x] `ruff`, `mypy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)