### PR TITLE
chore: move test dependencies from extra to dependency group

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,13 +48,6 @@ nrf-ota = [
 silabs-ota = [
     "silabs-ble-ota>=0.1.0",
 ]
-test = [
-    "pytest>=9.0.2",
-    "pytest-asyncio>=1.3.0",
-    "pytest-cov>=7.0.0",
-    "pytest-xdist>=3.8.0",
-    "hypothesis>=6.148.8",
-]
 
 [project.urls]
 Homepage = "https://opendisplay.org"
@@ -123,4 +116,12 @@ dev = [
     "ruff>=0.14.10",
     "prek>=0.3.4",
     "pylint>=4.0.5",
+    { include-group = "test" },
+]
+test = [
+    "pytest>=9.0.2",
+    "pytest-asyncio>=1.3.0",
+    "pytest-cov>=7.0.0",
+    "pytest-xdist>=3.8.0",
+    "hypothesis>=6.148.8",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -109,7 +109,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiooui" },
     { name = "bleak" },
-    { name = "dbus-fast" },
+    { name = "dbus-fast", marker = "sys_platform == 'linux'" },
     { name = "uart-devices" },
     { name = "usb-devices" },
 ]
@@ -914,6 +914,19 @@ nrf-ota = [
 silabs-ota = [
     { name = "silabs-ble-ota" },
 ]
+
+[package.dev-dependencies]
+dev = [
+    { name = "hypothesis" },
+    { name = "mypy" },
+    { name = "prek" },
+    { name = "pylint" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-cov" },
+    { name = "pytest-xdist" },
+    { name = "ruff" },
+]
 test = [
     { name = "hypothesis" },
     { name = "pytest" },
@@ -922,39 +935,38 @@ test = [
     { name = "pytest-xdist" },
 ]
 
-[package.dev-dependencies]
-dev = [
-    { name = "mypy" },
-    { name = "prek" },
-    { name = "pylint" },
-    { name = "ruff" },
-]
-
 [package.metadata]
 requires-dist = [
     { name = "bleak", specifier = ">=1.0.1" },
     { name = "bleak-retry-connector", specifier = ">=3.5.0" },
     { name = "cryptography", specifier = ">=41.0.0" },
     { name = "epaper-dithering", specifier = "==5.0.6" },
-    { name = "hypothesis", marker = "extra == 'test'", specifier = ">=6.148.8" },
     { name = "nrf-ota", marker = "extra == 'nrf-ota'", specifier = ">=0.4.0" },
     { name = "numpy", specifier = ">=1.24.0,!=2.4.0" },
     { name = "pillow", specifier = ">=10.0.0" },
-    { name = "pytest", marker = "extra == 'test'", specifier = ">=9.0.2" },
-    { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=1.3.0" },
-    { name = "pytest-cov", marker = "extra == 'test'", specifier = ">=7.0.0" },
-    { name = "pytest-xdist", marker = "extra == 'test'", specifier = ">=3.8.0" },
     { name = "rich", marker = "extra == 'cli'", specifier = ">=13.0.0" },
     { name = "silabs-ble-ota", marker = "extra == 'silabs-ota'", specifier = ">=0.1.0" },
 ]
-provides-extras = ["cli", "nrf-ota", "silabs-ota", "test"]
+provides-extras = ["cli", "nrf-ota", "silabs-ota"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "hypothesis", specifier = ">=6.148.8" },
     { name = "mypy", specifier = ">=1.19.1" },
     { name = "prek", specifier = ">=0.3.4" },
     { name = "pylint", specifier = ">=4.0.5" },
+    { name = "pytest", specifier = ">=9.0.2" },
+    { name = "pytest-asyncio", specifier = ">=1.3.0" },
+    { name = "pytest-cov", specifier = ">=7.0.0" },
+    { name = "pytest-xdist", specifier = ">=3.8.0" },
     { name = "ruff", specifier = ">=0.14.10" },
+]
+test = [
+    { name = "hypothesis", specifier = ">=6.148.8" },
+    { name = "pytest", specifier = ">=9.0.2" },
+    { name = "pytest-asyncio", specifier = ">=1.3.0" },
+    { name = "pytest-cov", specifier = ">=7.0.0" },
+    { name = "pytest-xdist", specifier = ">=3.8.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

pytest, pytest-asyncio, pytest-cov, pytest-xdist, and hypothesis lived in the `[project.optional-dependencies] test` **extra**. Extras are not installed by a plain `uv run`, so `uv run pytest` in a fresh checkout or git worktree silently fell back to whatever pytest is on $PATH — running the tests under a different interpreter against whatever `opendisplay` *that* interpreter could import (in the worst case, a stale editable install of a different checkout), instead of the tree under test.

This moves them to a `test` **dependency group**, included in `dev`, so they are synced by default and `uv run pytest` always uses the project venv. Test extras are development tooling, not publishable package metadata, so a group is also the semantically right home ([uv docs](https://docs.astral.sh/uv/concepts/projects/dependencies/#dependency-groups)).

No workflow or docs changes needed: `test.yml`/`lint.yml`/README all use `uv sync --all-extras` (± `--group dev`), which installs the default `dev` group; nothing referenced the `test` extra by name.

## Test plan

- [x] fresh venv, plain `uv run pytest`: resolves `.venv/bin/pytest` and imports `opendisplay` from the current tree (previously: system pytest + foreign editable install)
- [x] `uv run --all-extras pytest -q` → 461 passed
- [x] `uv lock` resolves cleanly; prek hooks (ruff/mypy/pylint) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)