### PR TITLE
fix: undefined DEFAULT_ZLIB_WINDOW_BITS in deferred compression path

### DIFF
--- a/src/opendisplay/device.py
+++ b/src/opendisplay/device.py
@@ -1397,14 +1397,18 @@ class OpenDisplayDevice:
         display_cfg = self._config.displays[0] if (self._config and self._config.displays) else None
         supports_compression = display_cfg.supports_zip if display_cfg else True
         uses_zipxl_window = bool(display_cfg and display_cfg.supports_zipxl)
-        if compress and supports_compression:
-            if uses_zipxl_window:
-                if compressed_data is None or zlib_window_bits(compressed_data) != ZIPXL_ZLIB_WINDOW_BITS:
-                    compressed_data = compress_image_data(image_data, level=6, window_bits=ZIPXL_ZLIB_WINDOW_BITS)
-            elif compressed_data is None:
-                # Lazy compression for the deferred/partial-fallback path: matches
-                # what prepare_image would have produced for a non-ZIPXL device.
-                compressed_data = compress_image_data(image_data, level=6, window_bits=DEFAULT_ZLIB_WINDOW_BITS)
+        if (
+            compress
+            and supports_compression
+            and (
+                compressed_data is None
+                or (uses_zipxl_window and zlib_window_bits(compressed_data) != ZIPXL_ZLIB_WINDOW_BITS)
+            )
+        ):
+            # Firmware only accepts zlib streams with a <=9-bit window regardless
+            # of ZIPXL (see prepare_image), so the lazy deferred/partial-fallback
+            # compression must use it too.
+            compressed_data = compress_image_data(image_data, level=6, window_bits=ZIPXL_ZLIB_WINDOW_BITS)
 
         within_compressed_limit = compressed_data is not None and (
             uses_zipxl_window or len(compressed_data) < MAX_COMPRESSED_SIZE

--- a/tests/unit/test_device_upload_flow.py
+++ b/tests/unit/test_device_upload_flow.py
@@ -393,6 +393,30 @@ async def test_dispatch_zipxl_recompresses_prepared_data_with_512_byte_window(
     assert zlib_window_bits(captured["compressed_data"]) == ZIPXL_ZLIB_WINDOW_BITS
 
 
+@pytest.mark.asyncio
+async def test_dispatch_non_zipxl_lazy_compression_uses_9bit_window(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Deferred compression (compressed_data=None) on a plain-ZIP device uses the 9-bit window."""
+    from opendisplay.encoding import ZIPXL_ZLIB_WINDOW_BITS, zlib_window_bits
+
+    # transmission_modes=0x02 → ZIP only, no ZIPXL
+    device = _make_device(transmission_modes=0x02)
+    captured: dict = {}
+
+    async def fake_execute(image_data, refresh_mode, use_compression=False, **kwargs):
+        captured["use_compression"] = use_compression
+        captured["compressed_data"] = kwargs["compressed_data"]
+
+    monkeypatch.setattr(device, "_execute_upload", fake_execute)
+    image_data = b"abc123" * 100
+
+    await device._dispatch_upload(image_data, RefreshMode.FULL, True, None, None)
+
+    assert captured["use_compression"] is True
+    assert zlib_window_bits(captured["compressed_data"]) == ZIPXL_ZLIB_WINDOW_BITS
+
+
 # ─── _execute_upload: error paths ────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Semantic conflict between #95 and #96 that git merged textually: #95's lazy-compression branch for non-ZIPXL devices calls `compress_image_data(..., window_bits=DEFAULT_ZLIB_WINDOW_BITS)`, but `device.py` never imports that name — the deferred/partial-fallback path on a plain-ZIP device raises `NameError` at runtime. And even with the import added, a 15-bit window would be wrong: since #96, firmware-bound streams must use the 9-bit window (`prepare_image` already does).

The deferred path now compresses with `ZIPXL_ZLIB_WINDOW_BITS` like everything else. Unchanged: ZIPXL window repair of caller-provided data, and the non-ZIPXL 50 KB compressed-size gate.

Caught by lint on #93's branch after syncing it with main; the test suite missed it because no test executed the lazy non-ZIPXL path — added one.

## Test plan

- [x] new regression test: plain-ZIP device (0x02), `compressed_data=None` → lazily compressed with 9-bit window (fails with NameError on main)
- [x] `pytest -q` → 493 passed
- [x] `ruff`, `mypy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)