### PR TITLE
fix: use CRC-16/CCITT for config CRC to match firmware/toolbox

### DIFF
--- a/src/opendisplay/protocol/config_serializer.py
+++ b/src/opendisplay/protocol/config_serializer.py
@@ -44,32 +44,44 @@ PACKET_TYPE_DATA_EXTENDED = 0x2C
 
 
 def calculate_config_crc(data: bytes) -> int:
-    """Calculate CRC32 and return lower 16 bits.
+    """Calculate the config-container CRC using CRC-16/CCITT-FALSE.
 
-    Uses standard CRC32 algorithm (same as zlib/firmware) but only returns
-    the lower 16 bits for backwards compatibility with firmware.
+    CRC-16/CCITT-FALSE: init 0xFFFF, polynomial 0x1021, MSB-first, no input or
+    output reflection, no final XOR. This is the canonical config CRC shared by
+    the nRF firmware, the Silabs firmware, and the website toolbox.
 
-    Firmware source: main.cpp:1543-1556, 1912-1914
-    The firmware calculates full CRC32 but only uses lower 16 bits.
+    The first two bytes of the container are the length field, which is excluded
+    from the CRC by forcing them to zero before feeding (mirroring the firmware's
+    config_toolbox_outer_crc16). This is done defensively here so the result is
+    correct whether the caller passes a zeroed length field (as serialize_config
+    does) or a populated one.
+
+    Firmware source: Firmware_NRF/config_parser.c config_toolbox_outer_crc16
+    (identical in Firmware_Silabs/opendisplay_config_parser.c).
 
     Args:
-        data: Config data to calculate CRC over
+        data: Config container body to calculate CRC over (everything except the
+            trailing 2 CRC bytes)
 
     Returns:
-        Lower 16 bits of CRC32 value
+        16-bit CRC value
     """
-    crc = 0xFFFFFFFF
+    buf = bytearray(data)
+    if len(buf) >= 2:
+        # Zero the length field (bytes 0-1) so it is excluded from the CRC.
+        buf[0] = 0
+        buf[1] = 0
 
-    for byte in data:
-        crc ^= byte
+    crc = 0xFFFF
+    for byte in buf:
+        crc ^= byte << 8
         for _ in range(8):
-            if crc & 1:
-                crc = (crc >> 1) ^ 0xEDB88320
+            if crc & 0x8000:
+                crc = ((crc << 1) ^ 0x1021) & 0xFFFF
             else:
-                crc = crc >> 1
+                crc = (crc << 1) & 0xFFFF
 
-    crc32 = (~crc) & 0xFFFFFFFF
-    return crc32 & 0xFFFF  # Return lower 16 bits only
+    return crc
 
 
 def serialize_system_config(config: SystemConfig) -> bytes:
@@ -528,7 +540,7 @@ def serialize_config(config: GlobalConfig) -> bytes:
     [2 bytes: padding/reserved]
     [1 byte: version]
     [TLV packets...]
-    [2 bytes: CRC16 (lower 16 bits of CRC32)]
+    [2 bytes: CRC-16/CCITT-FALSE, little-endian]
 
     TLV Packet Format:
     [1 byte: packet_number]  # 0-3 for repeatable types

--- a/tests/unit/test_config_crc.py
+++ b/tests/unit/test_config_crc.py
@@ -1,0 +1,77 @@
+"""Tests for the config-container CRC (CRC-16/CCITT-FALSE).
+
+The config CRC is the canonical CRC shared by the nRF firmware, the Silabs
+firmware, and the website toolbox: CRC-16/CCITT-FALSE (init 0xFFFF, poly 0x1021,
+MSB-first, no reflection, no final XOR) computed over the container body with the
+two length bytes forced to zero.
+
+Ground-truth vectors are taken from Firmware_NRF/config_parser.c
+(config_toolbox_outer_crc16).
+"""
+
+from __future__ import annotations
+
+import struct
+
+from opendisplay.protocol.config_parser import parse_tlv_config
+from opendisplay.protocol.config_serializer import calculate_config_crc, serialize_config
+
+
+def _packet(number: int, packet_type: int, payload: bytes) -> bytes:
+    return bytes([number, packet_type]) + payload
+
+
+def _system_payload() -> bytes:
+    return struct.pack("<HBBB", 1, 0, 0, 0) + (b"\x00" * 17)
+
+
+def _manufacturer_payload() -> bytes:
+    return struct.pack("<HBB", 1, 0, 1) + (b"\x00" * 18)
+
+
+def _power_payload() -> bytes:
+    return (
+        bytes([1])
+        + (1000).to_bytes(3, byteorder="little")
+        + struct.pack("<HbBBBBBHIH", 1000, 0, 0, 0xFF, 0xFF, 0, 1, 100, 0, 0)
+        + (b"\x00" * 10)
+    )
+
+
+def _required_tlv() -> bytes:
+    return (
+        _packet(0, 0x01, _system_payload())
+        + _packet(1, 0x02, _manufacturer_payload())
+        + _packet(2, 0x04, _power_payload())
+        + _packet(3, 0x20, b"\x00" * 46)
+    )
+
+
+# ── Ground-truth vectors ──────────────────────────────────────────────────────
+def test_crc_vector_000001() -> None:
+    assert calculate_config_crc(bytes.fromhex("000001")) == 0xDCBD
+
+
+def test_crc_vector_2a0001aabb() -> None:
+    assert calculate_config_crc(bytes.fromhex("2a0001aabb")) == 0xC239
+
+
+def test_crc_length_field_is_zeroed() -> None:
+    # [len_lo len_hi] 01 0001 + fourteen 00 bytes -> 0x0D7F for ANY length bytes,
+    # which proves the length field is excluded from the CRC.
+    body_tail = bytes.fromhex("010001") + (b"\x00" * 14)
+    assert calculate_config_crc(bytes.fromhex("4200") + body_tail) == 0x0D7F
+    assert calculate_config_crc(bytes.fromhex("0000") + body_tail) == 0x0D7F
+
+
+# ── serialize_config round-trip ───────────────────────────────────────────────
+def test_serialize_config_appends_predicted_crc() -> None:
+    config = parse_tlv_config(_required_tlv())
+    blob = serialize_config(config)
+
+    body, stored_crc = blob[:-2], int.from_bytes(blob[-2:], "little")
+
+    # Stored CRC is little-endian CRC-16/CCITT-FALSE over the body.
+    assert stored_crc == calculate_config_crc(body)
+    # serialize_config writes a zeroed length field, so zeroing it again is a no-op.
+    assert body[0:2] == b"\x00\x00"


### PR DESCRIPTION
## Problem

The config-container CRC is implemented three different ways across the project. The nRF firmware, the Silabs firmware, and the website toolbox all use **CRC-16/CCITT-FALSE**, but this Python library used the low 16 bits of a **CRC32** (poly `0xEDB88320`). A config serialized by this library therefore carries a CRC that none of the firmwares or the toolbox would recognize.

## Decision

Standardize on **CRC-16/CCITT-FALSE**. Most deployed displays were configured via the website toolbox, which writes CCITT, so CCITT is the canonical value. The CRC stays **advisory / non-enforced** — nothing in the library rejects a config based on its CRC, and this change does not introduce any rejection. The read side (`parse_config_response`) already ignores the stored CRC entirely.

## Fix

Rewrote `calculate_config_crc` as CRC-16/CCITT-FALSE: init `0xFFFF`, poly `0x1021`, MSB-first, no input/output reflection, no final XOR. The two length bytes (container bytes 0-1) are forced to zero before feeding, mirroring the firmware's `config_toolbox_outer_crc16`. This zeroing is done defensively so the result is correct whether the caller passes a zeroed length field (as `serialize_config` does today) or a populated one. The stored CRC remains little-endian in the trailing 2 bytes. Docstrings updated to match (the old one cited a nonexistent `main.cpp` CRC32).

Firmware reference: `Firmware_NRF/config_parser.c` `config_toolbox_outer_crc16` (identical in `Firmware_Silabs/opendisplay_config_parser.c`).

## Testing

New `tests/unit/test_config_crc.py` asserts the canonical ground-truth vectors from the firmware:

- `000001` → `0xDCBD`
- `2a0001aabb` → `0xC239`
- `[len] 01 0001` + 14 × `00` → `0x0D7F` for **any** length-byte value (proves length-zeroing)

plus a `serialize_config` round-trip confirming the appended CRC equals `calculate_config_crc(body)`.

Full suite: **497 passed** (`uv run --extra test --extra nrf-ota --extra silabs-ota pytest -q`). No existing test asserted the old CRC32 value, so no expected values needed updating.

## Note

This is a behavioral change to the emitted CRC **by design** — configs serialized by this library will now carry the canonical CCITT CRC instead of the old CRC32-low16. It stays advisory and is not enforced anywhere.

Part of the config-CRC CCITT standardization (finding MJ-7); companion changes in OpenDisplay/Firmware (Arduino toolbox-outer CRC) and OpenDisplay/opendisplay.org (ble-common.js read-back). Cross-links to be added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012g2e8mr132vcizx92WsgiR

---
**Related PRs — config-CRC CCITT standardization (finding MJ-7):**
- OpenDisplay/py-opendisplay#117 — Python client `calculate_config_crc` → CCITT
- OpenDisplay/Firmware#83 — Arduino toolbox-outer validation → CCITT (advisory)
- OpenDisplay/opendisplay.org#27 — website `parseConfigBytes` read-back (zero length bytes)

Already canonical (no change): toolbox writer, nRF firmware, Silabs firmware. `opendisplay-js` (TS) intentionally not updated (abandoned).