### PR TITLE
Harden client against truncated config reads and both compressed-failure frames

### DIFF
--- a/src/opendisplay/__init__.py
+++ b/src/opendisplay/__init__.py
@@ -21,6 +21,7 @@ from .exceptions import (
     OTAError,
     OTANotSupportedError,
     ProtocolError,
+    TruncatedConfigError,
 )
 from .landing import LANDING_URL_PREFIX, build_landing_payload, build_landing_url
 from .models.advertisement import (
@@ -99,6 +100,7 @@ __all__ = [
     "BLETimeoutError",
     "ProtocolError",
     "ConfigParseError",
+    "TruncatedConfigError",
     "InvalidResponseError",
     "ImageEncodingError",
     "OTAError",

--- a/src/opendisplay/device.py
+++ b/src/opendisplay/device.py
@@ -43,6 +43,7 @@ from .exceptions import (
     ImageEncodingError,
     InvalidResponseError,
     ProtocolError,
+    TruncatedConfigError,
 )
 from .landing import build_landing_url
 from .models.buzzer_activate import BuzzerActivateConfig
@@ -88,6 +89,7 @@ from .protocol import (
 )
 from .protocol.responses import (
     check_response_type,
+    is_compressed_failure_frame,
     parse_authenticate_challenge,
     parse_authenticate_success,
     strip_command_echo,
@@ -837,13 +839,27 @@ class OpenDisplayDevice:
 
         _LOGGER.debug("First chunk: %d bytes, total length: %d", len(chunk_data), total_length)
 
-        # Read remaining chunks
+        # Read remaining chunks. Firmware caps config-read chunks, so a broken or
+        # older firmware can stop sending before `total_length` is reached. Guard
+        # against both a mid-transfer read timeout and a stalled transfer (empty
+        # chunk making no progress) so we raise a typed error instead of hanging
+        # or returning a partial config.
         while len(tlv_data) < total_length:
-            next_response = await self._read(self.TIMEOUT_CONFIG_CHUNK)
+            try:
+                next_response = await self._read(self.TIMEOUT_CONFIG_CHUNK)
+            except BLETimeoutError as err:
+                raise TruncatedConfigError(
+                    f"Config read truncated: device stopped sending chunks at {len(tlv_data)}/{total_length} bytes"
+                ) from err
             next_chunk_data = strip_command_echo(next_response, CommandCode.READ_CONFIG)
 
             # Skip chunk number field (2 bytes) and append data
-            tlv_data.extend(next_chunk_data[2:])
+            chunk_payload = next_chunk_data[2:]
+            if not chunk_payload:
+                raise TruncatedConfigError(
+                    f"Config read stalled: device sent an empty chunk at {len(tlv_data)}/{total_length} bytes"
+                )
+            tlv_data.extend(chunk_payload)
 
             _LOGGER.debug(
                 "Received chunk, total: %d/%d bytes",
@@ -1705,11 +1721,19 @@ class OpenDisplayDevice:
                 raise
             # Device rejected the compressed START. Fall back to the uncompressed
             # protocol and retry; the same image_data (for 4-gray, the two split
-            # planes) streams fine uncompressed.
-            _LOGGER.warning(
-                "Compressed START rejected by device (0x%04x); falling back to uncompressed",
-                int.from_bytes(response[:2], "big"),
-            )
+            # planes) streams fine uncompressed. Firmware may report the failure as
+            # the legacy {0xFF, 0xFF} frame or the spec-conformant {0xFF, 0x70}
+            # ({0xFF, <cmd low byte>}); both are recognized as the same signal.
+            if is_compressed_failure_frame(response):
+                _LOGGER.warning(
+                    "Device signalled compressed-write failure (0x%04x); falling back to uncompressed",
+                    int.from_bytes(response[:2], "big"),
+                )
+            else:
+                _LOGGER.warning(
+                    "Compressed START rejected by device (0x%04x); falling back to uncompressed",
+                    int.from_bytes(response[:2], "big"),
+                )
             use_compression = False
             start_cmd = build_direct_write_start_uncompressed()
             await self._write(start_cmd)

--- a/src/opendisplay/exceptions.py
+++ b/src/opendisplay/exceptions.py
@@ -33,6 +33,18 @@ class ConfigParseError(ProtocolError):
     pass
 
 
+class TruncatedConfigError(ConfigParseError):
+    """Device stopped sending config chunks before the advertised length.
+
+    Raised during interrogate() when a config-read transfer stalls — a chunk
+    read times out mid-transfer, or the device sends an empty chunk making no
+    progress toward the total length — instead of hanging or returning a
+    partial config.
+    """
+
+    pass
+
+
 class InvalidResponseError(ProtocolError):
     """Device returned invalid response."""
 

--- a/src/opendisplay/protocol/responses.py
+++ b/src/opendisplay/protocol/responses.py
@@ -62,6 +62,26 @@ def strip_command_echo(data: bytes, expected_cmd: CommandCode) -> bytes:
     return data
 
 
+def is_compressed_failure_frame(response: bytes) -> bool:
+    """Return True if ``response`` is a firmware compressed-direct-write failure frame.
+
+    Firmware signals that it cannot honor a compressed DIRECT_WRITE_START by
+    replying with a 2-byte error frame. Older firmware sends the non-conformant
+    ``{0xFF, 0xFF}``; spec-conformant firmware sends ``{0xFF, <cmd low byte>}``
+    i.e. ``{0xFF, 0x70}``. Both mean "fall back to the uncompressed protocol",
+    so the client accepts either form.
+    """
+    return (
+        len(response) == 2
+        and response[0] == 0xFF
+        and response[1]
+        in (
+            0xFF,
+            CommandCode.DIRECT_WRITE_START & 0xFF,
+        )
+    )
+
+
 def check_response_type(response: bytes) -> tuple[CommandCode, bool]:
     """Check response type and whether it's an ACK.
 

--- a/tests/unit/test_device_upload_flow.py
+++ b/tests/unit/test_device_upload_flow.py
@@ -319,6 +319,28 @@ async def test_compressed_start_rejected_retries_uncompressed() -> None:
 
 
 @pytest.mark.asyncio
+async def test_compressed_start_rejected_spec_frame_retries_uncompressed() -> None:
+    """Spec-conformant {0xFF, 0x70} failure frame also triggers uncompressed fallback."""
+    image_data = b"\x00" * 10
+    compressed = b"\xff" * 5
+    device = _make_device()
+    spec_err_frame = b"\xff\x70"  # {0xFF, <DIRECT_WRITE_START low byte>}
+    fake = _FakeConnection([spec_err_frame, ACK_START, ACK_DATA, ACK_END, ACK_REFRESH])
+    device._connection = fake
+    await device._execute_upload(
+        image_data,
+        RefreshMode.FULL,
+        use_compression=True,
+        compressed_data=compressed,
+        uncompressed_size=len(image_data),
+    )
+    # First cmd: compressed START (size + data embedded); second: bare uncompressed START.
+    assert len(fake.written[0]) > 2
+    assert fake.written[0][:2] == b"\x00\x70"
+    assert fake.written[1] == b"\x00\x70"
+
+
+@pytest.mark.asyncio
 async def test_after_fallback_data_chunks_use_uncompressed_timeout() -> None:
     """After fallback to uncompressed, DATA chunk ACKs must use 90s timeout."""
     image_data = b"\x00" * 10

--- a/tests/unit/test_protocol_error_frames.py
+++ b/tests/unit/test_protocol_error_frames.py
@@ -8,9 +8,18 @@ import pytest
 from epaper_dithering import ColorScheme
 
 from opendisplay import OpenDisplayDevice
-from opendisplay.exceptions import InvalidResponseError, ProtocolError
+from opendisplay.exceptions import (
+    BLETimeoutError,
+    InvalidResponseError,
+    ProtocolError,
+    TruncatedConfigError,
+)
 from opendisplay.models.capabilities import DeviceCapabilities
-from opendisplay.protocol.responses import check_response_type, unpack_command_code
+from opendisplay.protocol.responses import (
+    check_response_type,
+    is_compressed_failure_frame,
+    unpack_command_code,
+)
 
 
 def test_unpack_command_code_short_raises_invalid_response() -> None:
@@ -44,3 +53,61 @@ def test_interrogate_reports_no_config_error_frame() -> None:
 
     with pytest.raises(ProtocolError, match="no stored configuration"):
         asyncio.run(device.interrogate())
+
+
+class _ScriptedConn:
+    """Replays scripted config-read responses; a scripted exception is raised."""
+
+    def __init__(self, responses: list[bytes | Exception]) -> None:
+        self._responses = responses
+
+    async def write_command(self, data: bytes) -> None:
+        pass
+
+    async def read_response(self, timeout: float) -> bytes:
+        item = self._responses.pop(0)
+        if isinstance(item, Exception):
+            raise item
+        return item
+
+
+def _make_device() -> OpenDisplayDevice:
+    return OpenDisplayDevice(
+        mac_address="AA:BB:CC:DD:EE:FF",
+        capabilities=DeviceCapabilities(width=2, height=2, color_scheme=ColorScheme.MONO),
+    )
+
+
+# First chunk: echo(0x0040) + chunkNum(0) + totalLen(100, little-endian) + 10 data bytes.
+# total_length (100) exceeds the delivered payload, so more chunks are expected.
+_FIRST_CHUNK = b"\x00\x40" + b"\x00\x00" + (100).to_bytes(2, "little") + b"\x01" * 10
+
+
+def test_interrogate_raises_on_config_read_timeout() -> None:
+    """A chunk read timing out mid-transfer raises TruncatedConfigError, not a hang."""
+    device = _make_device()
+    device._connection = _ScriptedConn([_FIRST_CHUNK, BLETimeoutError()])  # type: ignore[assignment]
+
+    with pytest.raises(TruncatedConfigError, match="truncated"):
+        asyncio.run(device.interrogate())
+
+
+def test_interrogate_raises_on_stalled_empty_chunk() -> None:
+    """An empty chunk (no progress) raises TruncatedConfigError instead of looping forever."""
+    device = _make_device()
+    # Second chunk carries only the echo + chunk number, no payload -> no progress.
+    empty_chunk = b"\x00\x40" + b"\x00\x01"
+    device._connection = _ScriptedConn([_FIRST_CHUNK, empty_chunk])  # type: ignore[assignment]
+
+    with pytest.raises(TruncatedConfigError, match="stalled"):
+        asyncio.run(device.interrogate())
+
+
+def test_is_compressed_failure_frame_accepts_both_forms() -> None:
+    """Both the legacy {0xFF,0xFF} and spec-conformant {0xFF,0x70} count as failures."""
+    assert is_compressed_failure_frame(b"\xff\xff") is True
+    assert is_compressed_failure_frame(b"\xff\x70") is True
+    # Not a failure frame: valid ACK, wrong prefix, or wrong length.
+    assert is_compressed_failure_frame(b"\x00\x70") is False
+    assert is_compressed_failure_frame(b"\xff\x40") is False
+    assert is_compressed_failure_frame(b"\xff") is False


### PR DESCRIPTION
Two client-robustness fixes.

## MJ-14 — Detect config-read truncation instead of hanging
The firmware caps config-read chunks (~958 B, being raised firmware-side). `interrogate()` loops `while len(tlv_data) < total_length`, so a firmware that stops sending chunks before `total_length` is reached could hang or return a partial config. The loop now guards both failure modes and raises a new typed `TruncatedConfigError` (subclass of `ConfigParseError`):
- a chunk read that times out mid-transfer, and
- a stalled transfer where the device sends an empty chunk making no progress.

The happy path is unchanged.

## MJ-16 — Tolerate both firmware compressed-failure frame formats
The firmware currently signals a compressed-direct-write failure with the legacy 2-byte `{0xFF, 0xFF}` frame; a companion firmware PR moves it to the spec-conformant `{0xFF, cmd}` (i.e. `{0xFF, 0x70}`). A new `is_compressed_failure_frame()` helper in `responses.py` recognizes **both** forms, and the compressed `DIRECT_WRITE_START` fallback uses it so the client falls back to the uncompressed protocol regardless of which frame the firmware sends.

This is backward-compatible (accepts old and new), so it can merge before or after the firmware `{0xFF, cmd}` PR.

## Tests
Added unit tests: a truncated config read (timeout and empty-chunk) raises `TruncatedConfigError` instead of hanging; both `{0xFF,0xFF}` and `{0xFF,0x70}` trigger the uncompressed fallback; `is_compressed_failure_frame()` accepts both forms and rejects non-failure frames.

`uv run --extra test --extra nrf-ota --extra silabs-ota pytest -q` → 502 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012g2e8mr132vcizx92WsgiR