### PR TITLE
fix: preserve PowerOption reserved bytes across JSON round-trip

### DIFF
--- a/src/opendisplay/models/config_json.py
+++ b/src/opendisplay/models/config_json.py
@@ -140,7 +140,7 @@ def config_to_json(config: GlobalConfig) -> dict[str, Any]:
                 "voltage_scaling_factor": f"0x{pwr.voltage_scaling_factor:x}",
                 "deep_sleep_current_ua": f"0x{pwr.deep_sleep_current_ua:x}",
                 "deep_sleep_time_seconds": f"0x{pwr.deep_sleep_time_seconds:x}",
-                "reserved": "0x0",
+                "reserved": _hex_bytes(pwr.reserved),
             },
         }
     )
@@ -506,7 +506,7 @@ def config_from_json(data: dict[str, Any]) -> GlobalConfig:
                 voltage_scaling_factor=_parse_int(fields.get("voltage_scaling_factor", "0")),
                 deep_sleep_current_ua=_parse_int(fields.get("deep_sleep_current_ua", "0")),
                 deep_sleep_time_seconds=_parse_int(fields.get("deep_sleep_time_seconds", "0")),
-                reserved=bytes(10),  # Fixed size
+                reserved=_parse_hex_bytes(fields.get("reserved", "0x0"), 10),
             )
 
         elif packet_id == 32:  # 0x20 = display

--- a/tests/unit/test_config_json_roundtrip.py
+++ b/tests/unit/test_config_json_roundtrip.py
@@ -15,27 +15,29 @@ from opendisplay.models.config import (
     SystemConfig,
 )
 from opendisplay.models.config_json import config_from_json, config_to_json
+from opendisplay.protocol.config_serializer import serialize_power_option
 
 
 def _base_config(**overrides) -> GlobalConfig:
+    power = overrides.pop("power", None) or PowerOption(
+        power_mode=0,
+        battery_capacity_mah=b"\x00\x00\x00",
+        sleep_timeout_ms=0,
+        tx_power=0,
+        sleep_flags=0,
+        battery_sense_pin=0xFF,
+        battery_sense_enable_pin=0xFF,
+        battery_sense_flags=0,
+        capacity_estimator=0,
+        voltage_scaling_factor=0,
+        deep_sleep_current_ua=0,
+        deep_sleep_time_seconds=0,
+        reserved=b"\x00" * 10,
+    )
     return GlobalConfig(
         system=SystemConfig(ic_type=0, communication_modes=0, device_flags=0, pwr_pin=0xFF, reserved=b"\x00" * 15),
         manufacturer=ManufacturerData(manufacturer_id=0, board_type=0, board_revision=0, reserved=b"\x00" * 6),
-        power=PowerOption(
-            power_mode=0,
-            battery_capacity_mah=b"\x00\x00\x00",
-            sleep_timeout_ms=0,
-            tx_power=0,
-            sleep_flags=0,
-            battery_sense_pin=0xFF,
-            battery_sense_enable_pin=0xFF,
-            battery_sense_flags=0,
-            capacity_estimator=0,
-            voltage_scaling_factor=0,
-            deep_sleep_current_ua=0,
-            deep_sleep_time_seconds=0,
-            reserved=b"\x00" * 10,
-        ),
+        power=power,
         **overrides,
     )
 
@@ -96,6 +98,35 @@ def test_binary_input_pins_and_reserved_survive_json_roundtrip() -> None:
     b = back.binary_inputs[0]
     assert b.reserved_pins == bytes([21, 22, 23, 24, 25, 26, 27, 28])
     assert b.reserved == bytes(range(14))  # ADC thresholds / power_off blob preserved
+
+
+def test_power_option_reserved_survives_json_roundtrip() -> None:
+    """PowerOption reserved bytes (offsets 20-29: charger pins, min_wake_time_seconds,
+    screen_timeout_seconds) must survive binary -> JSON -> binary instead of being zeroed."""
+    # Non-zero sentinel occupying all 10 reserved bytes (wire offsets 20-29).
+    sentinel = bytes([0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA])
+    power = PowerOption(
+        power_mode=0,
+        battery_capacity_mah=b"\x00\x00\x00",
+        sleep_timeout_ms=0,
+        tx_power=0,
+        sleep_flags=0,
+        battery_sense_pin=0xFF,
+        battery_sense_enable_pin=0xFF,
+        battery_sense_flags=0,
+        capacity_estimator=0,
+        voltage_scaling_factor=0,
+        deep_sleep_current_ua=0,
+        deep_sleep_time_seconds=0,
+        reserved=sentinel,
+    )
+    cfg = _base_config(displays=[_display()], power=power)
+
+    back = config_from_json(config_to_json(cfg))
+
+    packet = serialize_power_option(back.power)
+    assert len(packet) == 30
+    assert packet[20:30] == sentinel  # offsets 20-29 preserved, not zeroed
 
 
 def test_legacy_zero_reserved_still_parses() -> None:


### PR DESCRIPTION
## Problem (data loss, live today)

The config JSON codec exports `power_option.reserved` as the literal string `"0x0"` and re-imports it as `bytes(10)`. Any **read → JSON → edit → write** round-trip therefore **silently zeroes offsets 20–29** of the 30-byte `PowerOption` packet.

Firmware `main` (`bcee206`/#100) now uses 6 of those former "reserved" bytes for real fields:

- `charge_enable_pin`, `charge_state_pin`, `charger_flags` (charger control)
- `min_wake_time_seconds` (0 → firmware default 120 s)
- `screen_timeout_seconds` (EPD keep-alive)

So a round-trip today disables charger control, reverts `min_wake_time_seconds` to its 120 s default, and turns EPD keep-alive off. See the cross-repo config audit (2026-07-13), Finding 2.

## Fix

Mirror the existing `binary_inputs` / `display` reserved-blob treatment already in this file:

- Export: `"reserved": "0x0"` → `"reserved": _hex_bytes(pwr.reserved)`
- Import: `reserved=bytes(10)` → `reserved=_parse_hex_bytes(fields.get("reserved", "0x0"), 10)`

`_parse_hex_bytes` is back-compatible with the legacy `"0x0"` scalar, so pre-existing JSON files still import cleanly (as all-zero, same as before).

## Test

Adds a regression test asserting a `PowerOption` with a non-zero sentinel at offsets 20–29 survives `config_to_json` → `config_from_json` → `serialize_power_option` byte-for-byte. Confirmed it fails on the old codec (bytes zeroed) and passes with the fix.

Full suite: 686 passed; `ruff check` clean; `mypy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)