### PR TITLE
Add Seeed reTerminal E-series battery SOC curve

### DIFF
--- a/src/opendisplay/battery.py
+++ b/src/opendisplay/battery.py
@@ -69,6 +69,34 @@ _SOC_SUPERCAP: list[tuple[int, int]] = [
     (3000, 0),
 ]
 
+# Seeed reTerminal E-series (E1001/E1002/E1003/E1004) single-cell LiPo, derived
+# from Seeed's own ESPHome reference config's calibrate_linear breakpoints (10%
+# steps). The odd 5%-step entries are the midpoints of the surrounding pair,
+# added for finer resolution.
+_SOC_SEEED_LI_ION: list[tuple[int, int]] = [
+    (4150, 100),
+    (4055, 95),
+    (3960, 90),
+    (3935, 85),
+    (3910, 80),
+    (3880, 75),
+    (3850, 70),
+    (3825, 65),
+    (3800, 60),
+    (3775, 55),
+    (3750, 50),
+    (3715, 45),
+    (3680, 40),
+    (3630, 35),
+    (3580, 30),
+    (3535, 25),
+    (3490, 20),
+    (3450, 15),
+    (3410, 10),
+    (3300, 5),
+    (3270, 0),
+]
+
 
 def _interpolate(table: list[tuple[int, int]], voltage_mv: int) -> int:
     """Linearly interpolate SOC from a voltage lookup table.
@@ -119,5 +147,7 @@ def voltage_to_percent(
             return _interpolate(_SOC_LITHIUM_PRIMARY, voltage_mv)
         case CapacityEstimator.SUPERCAP:
             return _interpolate(_SOC_SUPERCAP, voltage_mv)
+        case CapacityEstimator.SEEED_LI_ION:
+            return _interpolate(_SOC_SEEED_LI_ION, voltage_mv)
         case _:
             return None

--- a/src/opendisplay/models/enums.py
+++ b/src/opendisplay/models/enums.py
@@ -159,6 +159,7 @@ class CapacityEstimator(IntEnum):
     LIFEPO4 = 2
     SUPERCAP = 3
     LITHIUM_PRIMARY = 4
+    SEEED_LI_ION = 5
 
 
 class LedType(IntEnum):

--- a/tests/unit/test_battery.py
+++ b/tests/unit/test_battery.py
@@ -38,6 +38,13 @@ from opendisplay.models.enums import CapacityEstimator
         # SUPERCAP — clamping
         (CapacityEstimator.SUPERCAP, 6000, 100),
         (CapacityEstimator.SUPERCAP, 1000, 0),
+        # SEEED_LI_ION — exact breakpoints (Seeed reTerminal E-series)
+        (CapacityEstimator.SEEED_LI_ION, 4150, 100),
+        (CapacityEstimator.SEEED_LI_ION, 3750, 50),
+        (CapacityEstimator.SEEED_LI_ION, 3270, 0),
+        # SEEED_LI_ION — clamping
+        (CapacityEstimator.SEEED_LI_ION, 4500, 100),
+        (CapacityEstimator.SEEED_LI_ION, 3000, 0),
     ],
 )
 def test_exact_values(chemistry: CapacityEstimator, voltage_mv: int, expected: int) -> None:
@@ -52,6 +59,8 @@ def test_exact_values(chemistry: CapacityEstimator, voltage_mv: int, expected: i
         (CapacityEstimator.LI_ION, 3770, 46, 48),
         # LIFEPO4 — midpoint between 3400 mV (90%) and 3350 mV (80%)
         (CapacityEstimator.LIFEPO4, 3375, 84, 86),
+        # SEEED_LI_ION — midpoint between 3960 mV (90%) and 3910 mV (80%)
+        (CapacityEstimator.SEEED_LI_ION, 3935, 84, 86),
     ],
 )
 def test_interpolation(chemistry: CapacityEstimator, voltage_mv: int, low: int, high: int) -> None:
@@ -73,6 +82,8 @@ def test_lifepo4_flat_plateau() -> None:
     [
         # raw int — CapacityEstimator.LI_ION == 1
         (1, 4200),
+        # raw int — CapacityEstimator.SEEED_LI_ION == 5
+        (5, 4150),
     ],
 )
 def test_accepts_raw_int_chemistry(chemistry: int, voltage_mv: int) -> None:


### PR DESCRIPTION
The generic LI_ION curve diverges significantly from Seeed's own discharge profile for the reTerminal E-series (E1001-E1004), e.g. reporting 76% vs the correct ~92% at 3.99V.

Add a dedicated SEEED_LI_ION chemistry with Seeed's ESPHome reference breakpoints from:
https://wiki.seeedstudio.com/reterminal_e10xx_with_esphome_advanced/