### PR TITLE
Fix ADC ladder BinaryInputs wire layout

### DIFF
--- a/src/opendisplay/models/config.py
+++ b/src/opendisplay/models/config.py
@@ -580,7 +580,9 @@ class DataBus:
 class BinaryInputs:
     """Binary inputs configuration (TLV packet type 0x25, repeatable max 4).
 
-    Size: 30 bytes (packed struct from firmware)
+    Size: 30 bytes (packed struct from firmware). Wire order is
+    ``button_data_byte_index``, ``power_off_flags``, ``power_off_hold_sec``,
+    then the 12-byte reserved tail.
     """
 
     instance_number: int  # uint8
@@ -591,12 +593,14 @@ class BinaryInputs:
     invert: int  # uint8 bitfield
     pullups: int  # uint8 bitfield
     pulldowns: int  # uint8 bitfield
-    reserved: bytes = b""  # 14 bytes
     button_data_byte_index: int = 0  # uint8 (v1+): dynamic return byte index (0-10)
+    power_off_flags: int = 0  # uint8 bitfield
+    power_off_hold_sec: int = 0  # uint8; 0 = firmware default
+    reserved: bytes = b""  # 12 bytes
 
     SIZE: ClassVar[int] = 30
-    # ADC ladder packs (N, id_base) + (N+1) LE uint16 thresholds into reserved[14].
-    MAX_LADDER_BUTTONS: ClassVar[int] = 5
+    # ADC ladder packs (N, id_base) + (N+1) LE uint16 thresholds into reserved[12].
+    MAX_LADDER_BUTTONS: ClassVar[int] = 4
     MAX_BUTTON_ID: ClassVar[int] = 7  # button id is a 3-bit field in the report byte
     MAX_BUTTON_DATA_BYTE_INDEX: ClassVar[int] = 10  # index into the 11-byte MSD block
 
@@ -646,7 +650,9 @@ class BinaryInputs:
             pullups=0,
             pulldowns=0,
             button_data_byte_index=button_data_byte_index,
-            reserved=reserved.ljust(14, b"\x00"),
+            power_off_flags=0,
+            power_off_hold_sec=0,
+            reserved=reserved.ljust(12, b"\x00"),
         )
 
     @classmethod
@@ -665,7 +671,9 @@ class BinaryInputs:
             pullups=data[13],
             pulldowns=data[14],
             button_data_byte_index=data[15],
-            reserved=data[16:30],
+            power_off_flags=data[16],
+            power_off_hold_sec=data[17],
+            reserved=data[18:30],
         )
 
 

--- a/src/opendisplay/models/config_json.py
+++ b/src/opendisplay/models/config_json.py
@@ -272,8 +272,9 @@ def config_to_json(config: GlobalConfig) -> dict[str, Any]:
                     "pullups": f"0x{binary_input.pullups:x}",
                     "pulldowns": f"0x{binary_input.pulldowns:x}",
                     "button_data_byte_index": f"0x{binary_input.button_data_byte_index:x}",
-                    # reserved holds ADC-ladder thresholds + power_off_flags/hold;
-                    # export the raw blob so a round-trip preserves them.
+                    "power_off_flags": f"0x{binary_input.power_off_flags:x}",
+                    "power_off_hold_sec": f"0x{binary_input.power_off_hold_sec:x}",
+                    # reserved is the canonical 12-byte tail, including ADC ladder data.
                     "reserved": _hex_bytes(binary_input.reserved),
                 },
             }
@@ -604,7 +605,9 @@ def config_from_json(data: dict[str, Any]) -> GlobalConfig:
                     pullups=_parse_int(fields.get("pullups", "0")),
                     pulldowns=_parse_int(fields.get("pulldowns", "0")),
                     button_data_byte_index=_parse_int(fields.get("button_data_byte_index", "0")),
-                    reserved=_parse_hex_bytes(fields.get("reserved", "0x0"), 14),
+                    power_off_flags=_parse_int(fields.get("power_off_flags", "0")),
+                    power_off_hold_sec=_parse_int(fields.get("power_off_hold_sec", "0")),
+                    reserved=_parse_hex_bytes(fields.get("reserved", "0x0"), 12),
                 )
             )
 

--- a/src/opendisplay/protocol/config_parser.py
+++ b/src/opendisplay/protocol/config_parser.py
@@ -498,7 +498,7 @@ def _parse_data_bus(data: bytes) -> DataBus:
 
 
 def _parse_binary_inputs(data: bytes) -> BinaryInputs:
-    """Parse BinaryInputs packet (0x25, 30 bytes)."""
+    """Parse BinaryInputs packet (0x25, 30 bytes) using the canonical field order."""
     if len(data) < 30:
         raise ConfigParseError(f"BinaryInputs too short: {len(data)} bytes (need 30)")
 
@@ -506,7 +506,9 @@ def _parse_binary_inputs(data: bytes) -> BinaryInputs:
     reserved_pins = data[3:11]  # 8 reserved pin bytes
     input_flags, invert, pullups, pulldowns = struct.unpack_from("<BBBB", data, 11)
     button_data_byte_index = data[15]
-    reserved = data[16:30]
+    power_off_flags = data[16]
+    power_off_hold_sec = data[17]
+    reserved = data[18:30]
 
     return BinaryInputs(
         instance_number=instance_num,
@@ -518,6 +520,8 @@ def _parse_binary_inputs(data: bytes) -> BinaryInputs:
         pullups=pullups,
         pulldowns=pulldowns,
         button_data_byte_index=button_data_byte_index,
+        power_off_flags=power_off_flags,
+        power_off_hold_sec=power_off_hold_sec,
         reserved=reserved,
     )
 

--- a/src/opendisplay/protocol/config_serializer.py
+++ b/src/opendisplay/protocol/config_serializer.py
@@ -447,10 +447,12 @@ def serialize_binary_inputs(config: BinaryInputs) -> bytes:
     data += bytes([config.button_data_byte_index & 0xFF])
 
     # Long-press power-off fields precede the remaining reserved tail.
-    data += bytes([
-        config.power_off_flags & 0xFF,
-        config.power_off_hold_sec & 0xFF,
-    ])
+    data += bytes(
+        [
+            config.power_off_flags & 0xFF,
+            config.power_off_hold_sec & 0xFF,
+        ]
+    )
 
     # Pad with reserved bytes to 30 total
     reserved = config.reserved if config.reserved else b"\x00" * 12

--- a/src/opendisplay/protocol/config_serializer.py
+++ b/src/opendisplay/protocol/config_serializer.py
@@ -413,7 +413,9 @@ def serialize_binary_inputs(config: BinaryInputs) -> bytes:
     - pullups: uint8
     - pulldowns: uint8
     - button_data_byte_index: uint8
-    - reserved: 14 bytes
+    - power_off_flags: uint8
+    - power_off_hold_sec: uint8
+    - reserved: 12 bytes
 
     Args:
         config: BinaryInputs instance
@@ -444,9 +446,15 @@ def serialize_binary_inputs(config: BinaryInputs) -> bytes:
     # Dynamic return byte index (v1+ firmware feature)
     data += bytes([config.button_data_byte_index & 0xFF])
 
+    # Long-press power-off fields precede the remaining reserved tail.
+    data += bytes([
+        config.power_off_flags & 0xFF,
+        config.power_off_hold_sec & 0xFF,
+    ])
+
     # Pad with reserved bytes to 30 total
-    reserved = config.reserved if config.reserved else b"\x00" * 14
-    return data + reserved[:14].ljust(14, b"\x00")
+    reserved = config.reserved if config.reserved else b"\x00" * 12
+    return data + reserved[:12].ljust(12, b"\x00")
 
 
 def serialize_security_config(config: SecurityConfig) -> bytes:

--- a/tests/unit/test_config_json_roundtrip.py
+++ b/tests/unit/test_config_json_roundtrip.py
@@ -85,7 +85,9 @@ def _binary_input() -> BinaryInputs:
         pullups=1,
         pulldowns=0,
         button_data_byte_index=4,
-        reserved=bytes(range(14)),
+        power_off_flags=0x05,
+        power_off_hold_sec=9,
+        reserved=bytes(range(12)),
     )
 
 
@@ -103,7 +105,9 @@ def test_binary_input_pins_and_reserved_survive_json_roundtrip() -> None:
     back = config_from_json(config_to_json(cfg))
     b = back.binary_inputs[0]
     assert b.reserved_pins == bytes([21, 22, 23, 24, 25, 26, 27, 28])
-    assert b.reserved == bytes(range(14))  # ADC thresholds / power_off blob preserved
+    assert b.power_off_flags == 0x05
+    assert b.power_off_hold_sec == 9
+    assert b.reserved == bytes(range(12))  # ADC ladder thresholds preserved
 
 
 def _sentinel_power() -> PowerOption:

--- a/tests/unit/test_required_packets.py
+++ b/tests/unit/test_required_packets.py
@@ -264,7 +264,9 @@ def test_config_to_json_binary_input_exports_button_data_byte_index() -> None:
                 pullups=0,
                 pulldowns=0,
                 button_data_byte_index=5,
-                reserved=b"\x00" * 14,
+                power_off_flags=0,
+                power_off_hold_sec=0,
+                reserved=b"\x00" * 12,
             )
         ],
     )
@@ -287,7 +289,9 @@ def test_serialize_binary_inputs_writes_button_data_byte_index_byte() -> None:
         pullups=0,
         pulldowns=0,
         button_data_byte_index=6,
-        reserved=b"\x00" * 14,
+        power_off_flags=0,
+        power_off_hold_sec=0,
+        reserved=b"\x00" * 12,
     )
 
     payload = serialize_binary_inputs(binary)
@@ -314,16 +318,17 @@ def test_adc_ladder_serializes_to_firmware_wire_contract() -> None:
     assert payload[1] == BinaryInputType.ADC_LADDER  # input_type
     assert payload[3] == 1  # reserved_pin_1 = ADC GPIO
     assert payload[15] == 5  # button_data_byte_index
-    # reserved[16:30] = N, id_base, then N+1 LE uint16 thresholds, zero-padded.
+    # offsets 16/17 are power-off fields; reserved[18:30] holds the ladder.
+    assert payload[16:18] == b"\x00\x00"
     expected_reserved = struct.pack("<BB", 4, 0) + struct.pack("<5H", 3850, 3163, 2132, 761, 0)
-    assert payload[16:30] == expected_reserved.ljust(14, b"\x00")
+    assert payload[18:30] == expected_reserved.ljust(12, b"\x00")
 
 
 @pytest.mark.parametrize(
     "thresholds",
     [
         [0],  # too few (N+1 must be >= 2)
-        [1, 2, 3, 4, 5, 6, 7],  # too many (N > MAX_LADDER_BUTTONS)
+        [1, 2, 3, 4, 5, 6],  # too many (N > MAX_LADDER_BUTTONS)
         [100, 100, 0],  # not strictly descending
         [100, 200, 0],  # ascending
         [70000, 0],  # threshold exceeds uint16


### PR DESCRIPTION
Updating to match the latest version of https://github.com/OpenDisplay/Firmware/pull/35 but we probably shouldn't merge until/unless it's merged.