### PR TITLE
fix: parse the trailing patch byte in the firmware version response

### DIFF
--- a/src/opendisplay/cli.py
+++ b/src/opendisplay/cli.py
@@ -305,7 +305,12 @@ def _info_to_json(data: dict[str, Any]) -> dict[str, Any]:
         }
         if wifi and wifi.ssid_text
         else None,
-        "firmware": {"major": fw["major"], "minor": fw["minor"], "sha": fw["sha"]},
+        "firmware": {
+            "major": fw["major"],
+            "minor": fw["minor"],
+            "patch": fw.get("patch", 0),
+            "sha": fw["sha"],
+        },
     }
 
 

--- a/src/opendisplay/models/firmware.py
+++ b/src/opendisplay/models/firmware.py
@@ -42,8 +42,11 @@ class FirmwareVersion(TypedDict):
         major: Major version number (0-255)
         minor: Minor version number (0-255)
         sha: Git commit SHA hash
+        patch: Patch version number (0-255); 0 when the firmware predates
+            the trailing patch byte in the version response
     """
 
     major: int
     minor: int
     sha: str
+    patch: int

--- a/src/opendisplay/protocol/responses.py
+++ b/src/opendisplay/protocol/responses.py
@@ -223,13 +223,17 @@ def parse_authenticate_success(data: bytes) -> bytes:
 def parse_firmware_version(data: bytes) -> FirmwareVersion:
     """Parse firmware version response.
 
-    Format: [echo:2][major:1][minor:1][shaLength:1][sha:variable]
+    Format: [echo:2][major:1][minor:1][shaLength:1][sha:variable][patch:1]
+
+    The trailing patch byte was added after the 2.25.0 firmware release; it
+    is placed after the SHA so older hosts that stop reading there keep
+    working. When absent, patch is reported as 0.
 
     Args:
         data: Raw firmware version response
 
     Returns:
-        FirmwareVersion dictionary with 'major', 'minor', and 'sha' fields
+        FirmwareVersion dictionary with 'major', 'minor', 'sha', and 'patch' fields
 
     Raises:
         InvalidResponseError: If response format invalid
@@ -265,10 +269,14 @@ def parse_firmware_version(data: bytes) -> FirmwareVersion:
     except UnicodeDecodeError as e:
         raise InvalidResponseError(f"Invalid SHA hash encoding (expected ASCII): {e}") from e
 
+    # Optional trailing patch byte (firmware > 2.25.0); absent on older firmware.
+    patch = data[5 + sha_length] if len(data) > 5 + sha_length else 0
+
     return {
         "major": major,
         "minor": minor,
         "sha": sha,
+        "patch": patch,
     }
 
 

--- a/tests/unit/test_protocol_responses.py
+++ b/tests/unit/test_protocol_responses.py
@@ -141,16 +141,31 @@ class TestParseFirmwareVersion:
 
     def test_parse_firmware_version_basic(self):
         """Test parsing firmware version with echo and SHA."""
-        # Format: [echo:2][major:1][minor:1][shaLength:1][sha:variable]
+        # Format: [echo:2][major:1][minor:1][shaLength:1][sha:variable][patch:1?]
         data = b"\x00\x43\x01\x05\x07gaberin"  # Version 1.5, SHA "gaberin"
         result = parse_firmware_version(data)
-        assert result == {"major": 1, "minor": 5, "sha": "gaberin"}
+        assert result == {"major": 1, "minor": 5, "sha": "gaberin", "patch": 0}
 
     def test_parse_firmware_version_with_ack_bit(self):
         """Test parsing with ACK bit set in echo."""
         data = b"\x80\x43\x02\x03\x04test"  # Version 2.3 with ACK, SHA "test"
         result = parse_firmware_version(data)
-        assert result == {"major": 2, "minor": 3, "sha": "test"}
+        assert result == {"major": 2, "minor": 3, "sha": "test", "patch": 0}
+
+    def test_parse_firmware_version_with_trailing_patch_byte(self):
+        """Firmware > 2.25.0 appends the patch version after the SHA."""
+        # Version 2.25.1, 40-char SHA, trailing patch byte
+        sha = "a" * 40
+        data = b"\x80\x43\x02\x19\x28" + sha.encode("ascii") + b"\x01"
+        result = parse_firmware_version(data)
+        assert result == {"major": 2, "minor": 25, "sha": sha, "patch": 1}
+
+    def test_parse_firmware_version_without_patch_byte_defaults_to_zero(self):
+        """Older firmware omits the trailing patch byte; patch reads as 0."""
+        sha = "b" * 40
+        data = b"\x80\x43\x02\x19\x28" + sha.encode("ascii")
+        result = parse_firmware_version(data)
+        assert result["patch"] == 0
 
     def test_parse_firmware_version_real_data(self, real_firmware_response):
         """Test parsing real firmware response from device."""


### PR DESCRIPTION
Found that I kept getting bugged to upgrade my XTEINK X4 firmware in the HA integration, even though I was at the latest, just-released 2.25.1. Tracked it down to this and a matching bug in the integration (I'll open a PR for it separately).

Commit message:

The firmware version response appends the patch version after the SHA ([echo][major][minor][shaLen][sha][patch]) so old hosts keep working. parse_firmware_version stopped reading at the SHA, so patch releases were invisible: a device running 2.25.1 reported as 2.25 and could never satisfy an update check against the 2.25.1 tag. Read the byte when present and expose it as FirmwareVersion['patch'] (0 when the firmware predates the field).