### PR TITLE
fix: show the patch component in the CLI tree and device log

### DIFF
--- a/src/opendisplay/cli.py
+++ b/src/opendisplay/cli.py
@@ -391,7 +391,7 @@ def _build_info_tree(data: dict[str, Any]) -> Tree:
         enc_str = enc_enum.name if isinstance(enc_enum, WifiEncryption) else f"0x{enc_enum:02x}"
         wf.add(f"Encryption    {enc_str}")
 
-    tree.add(f"[bold]Firmware[/bold]          {fw['major']}.{fw['minor']}  [dim](sha: {fw['sha']})[/dim]")
+    tree.add(f"[bold]Firmware[/bold]          {fw['major']}.{fw['minor']}.{fw['patch']}  [dim](sha: {fw['sha']})[/dim]")
     return tree
 
 

--- a/src/opendisplay/device.py
+++ b/src/opendisplay/device.py
@@ -1067,9 +1067,10 @@ class OpenDisplayDevice:  # pylint: disable=too-many-instance-attributes
         self._fw_version = parse_firmware_version(response)
 
         _LOGGER.info(
-            "Firmware version: %d.%d (SHA: %s...)",
+            "Firmware version: %d.%d.%d (SHA: %s...)",
             self._fw_version["major"],
             self._fw_version["minor"],
+            self._fw_version["patch"],
             self._fw_version["sha"][:8],
         )
 

--- a/tests/unit/test_protocol_responses.py
+++ b/tests/unit/test_protocol_responses.py
@@ -167,6 +167,17 @@ class TestParseFirmwareVersion:
         result = parse_firmware_version(data)
         assert result["patch"] == 0
 
+    def test_parse_firmware_version_patch_read_at_sha_boundary(self):
+        """The patch byte is read at 5 + sha_length, not at a fixed offset.
+
+        The cases above both use a 40-char SHA, so an off-by-one in that index
+        would still pass them. With a one-character SHA a wrong offset reads
+        "9" (0x39) or runs off the end instead of 7.
+        """
+        data = b"\x00\x43\x03\x00\x01" + b"9" + b"\x07"
+        result = parse_firmware_version(data)
+        assert result == {"major": 3, "minor": 0, "patch": 7, "sha": "9"}
+
     def test_parse_firmware_version_real_data(self, real_firmware_response):
         """Test parsing real firmware response from device."""
         if real_firmware_response and len(real_firmware_response) >= 5:


### PR DESCRIPTION
The firmware version response carries a trailing patch byte, and the parser reads it — but two of the places that render a version string still print only two components. A device running 2.25.1 shows up as `2.25`:

- **`cli.py:394`** — `_build_info_tree`, the human-readable output of `opendisplay info`. The JSON path (`_info_to_json`) already includes the patch; this is the one people actually look at.
- **`device.py:1070`** — `_LOGGER.info("Firmware version: %d.%d (SHA: %s...)")`.

Both now render `major.minor.patch`. Firmware predating the trailing byte parses as patch 0 and renders as e.g. `2.23.0`.

## Test

Adds a parse case with a one-character SHA:

```python
data = b"\x00\x43\x03\x00\x01" + b"9" + b"\x07"
assert parse_firmware_version(data) == {"major": 3, "minor": 0, "patch": 7, "sha": "9"}
```

The existing cases all use a 40-char SHA, so an off-by-one in the `5 + sha_length` index would still pass them — this one reads `"9"` (0x39) or runs off the end if the offset is wrong.

## Checks

`uv run pytest` — 863 passed. `uv run prek run --all-files` — ruff, ruff-format, mypy strict, pylint all pass.