### PR TITLE
fix: stop stray BLE notifications from desyncing reads and corrupting config

### DIFF
--- a/src/opendisplay/device.py
+++ b/src/opendisplay/device.py
@@ -134,7 +134,9 @@ from .protocol.responses import (
     PIPE_START_NACK_PARTIAL_UNSUPPORTED,
     PIPE_START_NACK_RECT_INVALID,
     check_response_type,
+    describe_command_code,
     is_compressed_failure_frame,
+    matches_command_echo,
     parse_authenticate_challenge,
     parse_authenticate_success,
     parse_read_msd,
@@ -446,6 +448,11 @@ class OpenDisplayDevice:  # pylint: disable=too-many-instance-attributes
     """
 
     _ENCRYPTED_RESPONSE_MIN_LEN = 31  # cmd(2) + nonce(16) + payload(1) + tag(12)
+
+    # Foreign frames tolerated while waiting for a config chunk before giving up.
+    # Bounded so a device streaming unrelated frames fails with a clear error
+    # instead of renewing the read timeout indefinitely.
+    MAX_STRAY_CONFIG_FRAMES = 8
 
     # BLE operation timeouts (seconds)
     TIMEOUT_FIRST_CHUNK = 10.0  # First chunk may take longer
@@ -1038,6 +1045,47 @@ class OpenDisplayDevice:  # pylint: disable=too-many-instance-attributes
                 pass
         return bytes.fromhex(self.mac_address.replace(":", ""))[-3:]
 
+    async def _read_config_frame(self, timeout: float) -> bytes:
+        """Read the next READ_CONFIG frame, ignoring frames from other commands.
+
+        The notification queue has no request/response correlation, so a frame
+        belonging to a different exchange — a duplicated response, or one the
+        firmware held in its TX ring until notifications were enabled — can land
+        mid-transfer. It must not reach ``strip_command_echo``, which returns a
+        non-matching frame *unchanged*: its 2-byte echo would then be consumed as
+        the chunk-number field and its body spliced into the config, silently
+        corrupting it (no length check catches this — the loop only counts bytes).
+        Skipping such frames keeps the config read on its own command stream.
+
+        The device's no-config error frame ({0xFF, 0x40, ...}) is passed through
+        rather than skipped: it answers this command and the caller reports it.
+
+        Raises:
+            BLETimeoutError: If no frame arrives within ``timeout``
+            ProtocolError: If more than ``MAX_STRAY_CONFIG_FRAMES`` foreign frames
+                arrive while waiting for this chunk
+        """
+        for _ in range(self.MAX_STRAY_CONFIG_FRAMES + 1):
+            response = await self._read(timeout)
+            if matches_command_echo(response, CommandCode.READ_CONFIG):
+                return response
+            # NACK form of the same command: {0xFF, <cmd low byte>, ...}
+            if len(response) >= 2 and response[0] == 0xFF and response[1] == CommandCode.READ_CONFIG:
+                return response
+            _LOGGER.warning(
+                "Ignoring stray %s frame (%d B) while reading config",
+                (
+                    describe_command_code(unpack_command_code(response))
+                    if len(response) >= 2
+                    else f"malformed {response.hex() or '<empty>'}"
+                ),
+                len(response),
+            )
+        raise ProtocolError(
+            f"Config read aborted: more than {self.MAX_STRAY_CONFIG_FRAMES} frames from other "
+            "commands arrived while waiting for a config chunk"
+        )
+
     @_serialized
     async def interrogate(self) -> GlobalConfig:
         """Read device configuration from device.
@@ -1055,7 +1103,7 @@ class OpenDisplayDevice:  # pylint: disable=too-many-instance-attributes
         await self._write(cmd)
 
         # Read first chunk
-        response = await self._read(self.TIMEOUT_FIRST_CHUNK)
+        response = await self._read_config_frame(self.TIMEOUT_FIRST_CHUNK)
 
         # Firmware answers a device-with-no-config with the 4-byte error frame
         # {0xFF, 0x40, 0x00, 0x00}. Without this check the {0x00,0x00} length
@@ -1078,7 +1126,7 @@ class OpenDisplayDevice:  # pylint: disable=too-many-instance-attributes
         # or returning a partial config.
         while len(tlv_data) < total_length:
             try:
-                next_response = await self._read(self.TIMEOUT_CONFIG_CHUNK)
+                next_response = await self._read_config_frame(self.TIMEOUT_CONFIG_CHUNK)
             except BLETimeoutError as err:
                 raise TruncatedConfigError(
                     f"Config read truncated: device stopped sending chunks at {len(tlv_data)}/{total_length} bytes"

--- a/src/opendisplay/protocol/responses.py
+++ b/src/opendisplay/protocol/responses.py
@@ -44,11 +44,63 @@ def unpack_command_code(data: bytes, offset: int = 0) -> int:
     return int(struct.unpack(">H", data[offset : offset + 2])[0])
 
 
+def describe_command_code(code: int) -> str:
+    """Return a ``NAME (0xnnnn)`` label for a response's command code.
+
+    Resolves the ACK high bit and the ``0xFF`` NACK prefix back to the underlying
+    command, so a frame logged while being dropped names the exchange it came
+    from rather than only its raw code. Unknown codes report bare hex.
+
+    Args:
+        code: 2-byte command code from a response
+
+    Returns:
+        Human-readable label, e.g. ``READ_FW_VERSION (0x0043)``
+    """
+    label = f"0x{code:04x}"
+    if (code >> 8) == 0xFF:
+        base, kind = code & 0xFF, " NACK"
+    elif code & RESPONSE_HIGH_BIT_FLAG:
+        base, kind = code & ~RESPONSE_HIGH_BIT_FLAG, " ACK"
+    else:
+        base, kind = code, ""
+    try:
+        return f"{CommandCode(base).name}{kind} ({label})"
+    except ValueError:
+        return label
+
+
+def matches_command_echo(data: bytes, expected_cmd: CommandCode) -> bool:
+    """Return True if ``data`` opens with ``expected_cmd``'s echo.
+
+    Firmware echoes commands in responses, sometimes with the ACK high bit set;
+    both forms count as a match. Callers use this to tell a response to the
+    command they sent from a frame belonging to some other exchange, which the
+    notification queue cannot distinguish on its own.
+
+    Args:
+        data: Response data from device
+        expected_cmd: Expected command echo
+
+    Returns:
+        True if the leading 2 bytes echo ``expected_cmd``
+    """
+    if len(data) < 2:
+        return False
+    echo = unpack_command_code(data)
+    return echo in (expected_cmd, expected_cmd | RESPONSE_HIGH_BIT_FLAG)
+
+
 def strip_command_echo(data: bytes, expected_cmd: CommandCode) -> bytes:
     """Strip command echo from response data.
 
     Firmware echoes commands in responses, sometimes with high bit set.
     This function removes the 2-byte echo if present.
+
+    A non-matching frame is returned unchanged rather than rejected, so callers
+    that can receive foreign frames must screen them with
+    :func:`matches_command_echo` first — otherwise the echo survives into the
+    payload and is parsed as data.
 
     Args:
         data: Response data from device
@@ -57,10 +109,8 @@ def strip_command_echo(data: bytes, expected_cmd: CommandCode) -> bytes:
     Returns:
         Data with echo stripped (if present), otherwise original data
     """
-    if len(data) >= 2:
-        echo = unpack_command_code(data)
-        if echo in (expected_cmd, expected_cmd | RESPONSE_HIGH_BIT_FLAG):
-            return data[2:]
+    if matches_command_echo(data, expected_cmd):
+        return data[2:]
     return data
 
 

--- a/src/opendisplay/transport/connection.py
+++ b/src/opendisplay/transport/connection.py
@@ -12,6 +12,7 @@ from bleak_retry_connector import BleakClientWithServiceCache, establish_connect
 
 from ..exceptions import BLEConnectionError, BLETimeoutError
 from ..protocol import SERVICE_UUID
+from ..protocol.responses import describe_command_code
 
 if TYPE_CHECKING:
     from bleak.backends.characteristic import BleakGATTCharacteristic
@@ -363,7 +364,7 @@ class BLEConnection:
 
     @staticmethod
     def _describe_dropped_frame(frame: bytes) -> str:
-        """Describe a discarded frame as ``0xNNNN (N B)`` for the drain log.
+        """Describe a discarded frame as ``NAME (0xnnnn) (N B)`` for the drain log.
 
         The 2-byte command echo leads every frame in the clear — encrypted
         responses carry it ahead of the nonce — so it identifies the leaking
@@ -372,7 +373,7 @@ class BLEConnection:
         """
         if len(frame) < 2:
             return f"malformed {frame.hex() or '<empty>'} ({len(frame)} B)"
-        return f"0x{int.from_bytes(frame[:2], 'big'):04x} ({len(frame)} B)"
+        return f"{describe_command_code(int.from_bytes(frame[:2], 'big'))} ({len(frame)} B)"
 
     def drain_notifications(self) -> int:
         """Discard any queued notifications and return how many were dropped.

--- a/src/opendisplay/transport/connection.py
+++ b/src/opendisplay/transport/connection.py
@@ -238,6 +238,11 @@ class BLEConnection:
             pass
         self._notification_characteristic = None
         self._client = None
+        # This path drops the client directly rather than via disconnect(), and a
+        # retried attempt reuses this object's queue: an attempt that got as far
+        # as starting notifications before failing can have queued a frame that
+        # would otherwise be read as the *next* attempt's first response.
+        self._flush_notification_queue("connect retry")
 
     async def disconnect(self) -> None:
         """Disconnect from device, releasing notifications first."""
@@ -254,6 +259,12 @@ class BLEConnection:
             finally:
                 self._notification_characteristic = None
                 self._client = None
+        # Outside the branch: the link can already be down (dropped underneath us,
+        # or a second disconnect()) and still have left frames queued. Not all
+        # bleak backends invoke disconnected_callback for a caller-initiated
+        # disconnect either, so this path must flush on its own rather than rely
+        # on _on_disconnect having run.
+        self._flush_notification_queue("disconnect")
 
     async def clear_cache(self) -> bool:
         """Clear the GATT services cache for this device.
@@ -329,6 +340,11 @@ class BLEConnection:
         via the registered ``disconnected_callback``.
         """
         _LOGGER.debug("BLE link to %s dropped", self.mac_address)
+        # Flush before notifying the owner: this is the only path guaranteed to
+        # run on an *unexpected* drop (device reboot, out of range, proxy reset),
+        # where disconnect() is never called and leftovers would otherwise ride
+        # into the next connect() on this object.
+        self._flush_notification_queue("link drop")
         if self._disconnected_callback is not None:
             try:
                 self._disconnected_callback()
@@ -345,6 +361,19 @@ class BLEConnection:
         # Put notification in queue for processing
         self._notification_queue.put_nowait(bytes(data))
 
+    @staticmethod
+    def _describe_dropped_frame(frame: bytes) -> str:
+        """Describe a discarded frame as ``0xNNNN (N B)`` for the drain log.
+
+        The 2-byte command echo leads every frame in the clear — encrypted
+        responses carry it ahead of the nonce — so it identifies the leaking
+        command on both plaintext and encrypted paths. Never raises: a frame too
+        short to carry an echo is reported verbatim rather than dropped silently.
+        """
+        if len(frame) < 2:
+            return f"malformed {frame.hex() or '<empty>'} ({len(frame)} B)"
+        return f"0x{int.from_bytes(frame[:2], 'big'):04x} ({len(frame)} B)"
+
     def drain_notifications(self) -> int:
         """Discard any queued notifications and return how many were dropped.
 
@@ -354,17 +383,54 @@ class BLEConnection:
         command and desync every subsequent read by one. Draining before writing
         a command clears such leftovers; in healthy stop-and-wait operation the
         queue is already empty here, so this is a no-op.
+
+        Each dropped frame is logged with its command echo. A bare count says a
+        desync happened but not why; the echo distinguishes a duplicated response
+        (same code as the command just completed) from a frame belonging to an
+        entirely different exchange (a cross-connection or pre-subscription leak).
         """
-        dropped = 0
+        dropped = self._drain_queue()
+        if dropped:
+            _LOGGER.warning(
+                "Discarded %d stale notification(s) before command: %s",
+                len(dropped),
+                ", ".join(dropped),
+            )
+        return len(dropped)
+
+    def _drain_queue(self) -> list[str]:
+        """Empty the notification queue, returning a descriptor per dropped frame.
+
+        Synchronous and non-raising so it is safe to call from bleak's disconnect
+        callback as well as from the pre-command drain.
+        """
+        dropped: list[str] = []
         while True:
             try:
-                self._notification_queue.get_nowait()
+                frame = self._notification_queue.get_nowait()
             except asyncio.QueueEmpty:
-                break
-            dropped += 1
-        if dropped:
-            _LOGGER.warning("Discarded %d stale notification(s) before command", dropped)
-        return dropped
+                return dropped
+            dropped.append(self._describe_dropped_frame(frame))
+
+    def _flush_notification_queue(self, reason: str) -> int:
+        """Discard notifications left over from a link that is gone.
+
+        A frame queued against a dead link can never answer a future command, so
+        carrying it across a reconnect would desync the first read on the new
+        link — this object is reusable, and ``connect()`` after ``disconnect()``
+        keeps the same queue. Called from every disconnect path, including the
+        stack-signalled one, so an unexpected drop flushes as thoroughly as a
+        graceful teardown.
+        """
+        flushed = self._drain_queue()
+        if flushed:
+            _LOGGER.debug(
+                "Flushed %d queued notification(s) on %s: %s",
+                len(flushed),
+                reason,
+                ", ".join(flushed),
+            )
+        return len(flushed)
 
     async def write_command(self, data: bytes, response: bool = True, drain_stale: bool = True) -> None:
         """Write command to device.

--- a/tests/unit/test_connection_notification_queue.py
+++ b/tests/unit/test_connection_notification_queue.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 
 import pytest
 
@@ -22,6 +23,91 @@ def test_drain_notifications_discards_all_queued() -> None:
 def test_drain_notifications_empty_queue_is_noop() -> None:
     conn = BLEConnection("AA:BB:CC:DD:EE:FF")
     assert conn.drain_notifications() == 0
+
+
+def test_drain_notifications_logs_command_echo_of_each_dropped_frame(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The warning names every dropped frame's echo, so a desync can be traced to
+    the command that leaked it instead of only being reported as a count."""
+    conn = BLEConnection("AA:BB:CC:DD:EE:FF")
+    conn._notification_queue.put_nowait(b"\x00\x40\x00\x01")  # stray READ_CONFIG chunk
+    conn._notification_queue.put_nowait(b"\x00\x50\x00")  # duplicated AUTHENTICATE reply
+
+    with caplog.at_level(logging.WARNING, logger="opendisplay.transport.connection"):
+        assert conn.drain_notifications() == 2
+
+    assert "0x0040 (4 B)" in caplog.text
+    assert "0x0050 (3 B)" in caplog.text
+
+
+def test_drain_notifications_describes_frame_too_short_for_an_echo(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A frame shorter than the 2-byte echo is reported verbatim, never dropped
+    silently and never raising out of the drain path."""
+    conn = BLEConnection("AA:BB:CC:DD:EE:FF")
+    conn._notification_queue.put_nowait(b"\xff")
+
+    with caplog.at_level(logging.WARNING, logger="opendisplay.transport.connection"):
+        assert conn.drain_notifications() == 1
+
+    assert "malformed ff (1 B)" in caplog.text
+
+
+def test_link_drop_callback_flushes_queued_frames() -> None:
+    """An unexpected drop never calls disconnect(), so the stack-signalled path
+    must flush on its own or leftovers ride into the next connect()."""
+    conn = BLEConnection("AA:BB:CC:DD:EE:FF")
+    conn._notification_queue.put_nowait(b"\x00\x40\x00\x01")
+
+    conn._on_disconnect(None)  # type: ignore[arg-type]  # client arg is unused
+
+    assert conn._notification_queue.empty()
+
+
+def test_link_drop_callback_still_notifies_owner_after_flushing() -> None:
+    """Flushing must not displace the owner notification that clears session state."""
+    notified: list[bool] = []
+    conn = BLEConnection("AA:BB:CC:DD:EE:FF", disconnected_callback=lambda: notified.append(True))
+    conn._notification_queue.put_nowait(b"\x00\x50\x00")
+
+    conn._on_disconnect(None)  # type: ignore[arg-type]
+
+    assert conn._notification_queue.empty()
+    assert notified == [True]
+
+
+@pytest.mark.asyncio
+async def test_disconnect_flushes_queue_when_link_already_down() -> None:
+    """disconnect() skips its teardown branch when the client is already gone, but
+    frames queued before the drop must still not survive into a reconnect."""
+    conn = BLEConnection("AA:BB:CC:DD:EE:FF")
+    conn._notification_queue.put_nowait(b"\x00\x40\x00\x01")
+
+    await conn.disconnect()
+
+    assert conn._notification_queue.empty()
+
+
+@pytest.mark.asyncio
+async def test_clear_cache_and_drop_flushes_queue_between_connect_attempts() -> None:
+    """A failed attempt that reached notification setup must not leave a frame for
+    the retry to read as its first response."""
+
+    class _FakeClient:
+        is_connected = False
+
+        async def disconnect(self) -> None:
+            return None
+
+    conn = BLEConnection("AA:BB:CC:DD:EE:FF")
+    conn._client = _FakeClient()  # type: ignore[assignment]
+    conn._notification_queue.put_nowait(b"\x00\x40\x00\x01")
+
+    await conn._clear_cache_and_drop()
+
+    assert conn._notification_queue.empty()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_connection_notification_queue.py
+++ b/tests/unit/test_connection_notification_queue.py
@@ -25,11 +25,11 @@ def test_drain_notifications_empty_queue_is_noop() -> None:
     assert conn.drain_notifications() == 0
 
 
-def test_drain_notifications_logs_command_echo_of_each_dropped_frame(
+def test_drain_notifications_logs_command_type_of_each_dropped_frame(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """The warning names every dropped frame's echo, so a desync can be traced to
-    the command that leaked it instead of only being reported as a count."""
+    """The warning names every dropped frame's command, so a desync can be traced
+    to the exchange that leaked it instead of only being reported as a count."""
     conn = BLEConnection("AA:BB:CC:DD:EE:FF")
     conn._notification_queue.put_nowait(b"\x00\x40\x00\x01")  # stray READ_CONFIG chunk
     conn._notification_queue.put_nowait(b"\x00\x50\x00")  # duplicated AUTHENTICATE reply
@@ -37,8 +37,17 @@ def test_drain_notifications_logs_command_echo_of_each_dropped_frame(
     with caplog.at_level(logging.WARNING, logger="opendisplay.transport.connection"):
         assert conn.drain_notifications() == 2
 
-    assert "0x0040 (4 B)" in caplog.text
-    assert "0x0050 (3 B)" in caplog.text
+    assert "READ_CONFIG (0x0040) (4 B)" in caplog.text
+    assert "AUTHENTICATE (0x0050) (3 B)" in caplog.text
+
+
+def test_drain_notifications_resolves_ack_and_nack_forms_to_their_command() -> None:
+    """A response carries the ACK high bit or the 0xFF NACK prefix; both must
+    resolve to the originating command rather than logging as unknown codes."""
+    assert BLEConnection._describe_dropped_frame(b"\x80\x40\x00") == "READ_CONFIG ACK (0x8040) (3 B)"
+    assert BLEConnection._describe_dropped_frame(b"\xff\x40\x00\x00") == "READ_CONFIG NACK (0xff40) (4 B)"
+    # Not a known command: reported as bare hex rather than guessed at.
+    assert BLEConnection._describe_dropped_frame(b"\x00\x99") == "0x0099 (2 B)"
 
 
 def test_drain_notifications_describes_frame_too_short_for_an_echo(

--- a/tests/unit/test_protocol_error_frames.py
+++ b/tests/unit/test_protocol_error_frames.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 
 import pytest
 from epaper_dithering import ColorScheme
@@ -10,6 +11,7 @@ from epaper_dithering import ColorScheme
 from opendisplay import OpenDisplayDevice
 from opendisplay.exceptions import (
     BLETimeoutError,
+    ConfigParseError,
     InvalidResponseError,
     ProtocolError,
     TruncatedConfigError,
@@ -100,6 +102,49 @@ def test_interrogate_raises_on_stalled_empty_chunk() -> None:
     device._connection = _ScriptedConn([_FIRST_CHUNK, empty_chunk])  # type: ignore[assignment]
 
     with pytest.raises(TruncatedConfigError, match="stalled"):
+        asyncio.run(device.interrogate())
+
+
+def test_interrogate_ignores_stray_frame_from_another_command(caplog: pytest.LogCaptureFixture) -> None:
+    """A frame belonging to a different exchange must not be spliced into the
+    config: strip_command_echo returns a non-matching frame unchanged, so its
+    echo would be eaten as the chunk-number field and its body appended as data.
+    """
+    device = _make_device()
+    # 90 payload bytes still owed after the first chunk's 10.
+    stray = b"\x00\x43\x01\x00\x28" + b"\xaa" * 20  # firmware-version reply, wrong exchange
+    real_chunk = b"\x00\x40" + b"\x00\x01" + b"\x02" * 90
+    device._connection = _ScriptedConn([_FIRST_CHUNK, stray, real_chunk])  # type: ignore[assignment]
+
+    with caplog.at_level(logging.WARNING, logger="opendisplay.device"), pytest.raises(ConfigParseError):
+        asyncio.run(device.interrogate())
+
+    # Reaching the parser at all proves total_length was satisfied by config
+    # chunks alone: the stray was consumed and dropped rather than appended.
+    assert "Ignoring stray READ_FW_VERSION (0x0043) frame" in caplog.text
+    assert device._connection._responses == []  # type: ignore[attr-defined]
+
+
+def test_interrogate_gives_up_after_too_many_stray_frames() -> None:
+    """Foreign frames are bounded, so a device streaming unrelated frames fails
+    with a clear error rather than renewing the read timeout indefinitely."""
+    device = _make_device()
+    stray = b"\x00\x43\x01\x00\x28"
+    strays: list[bytes | Exception] = [stray] * (OpenDisplayDevice.MAX_STRAY_CONFIG_FRAMES + 1)
+    device._connection = _ScriptedConn([_FIRST_CHUNK, *strays])  # type: ignore[assignment]
+
+    with pytest.raises(ProtocolError, match="frames from other commands"):
+        asyncio.run(device.interrogate())
+
+
+def test_interrogate_still_reports_error_frame_after_a_stray() -> None:
+    """The no-config NACK answers this command, so it is passed through to the
+    caller rather than skipped as a foreign frame."""
+    device = _make_device()
+    stray = b"\x00\x43\x01\x00\x28"
+    device._connection = _ScriptedConn([stray, b"\xff\x40\x00\x00"])  # type: ignore[assignment]
+
+    with pytest.raises(ProtocolError, match="no stored configuration"):
         asyncio.run(device.interrogate())
 
 


### PR DESCRIPTION
## Problem

The notification queue (`BLEConnection._notification_queue`) is a plain FIFO of raw frames with no request/response correlation — `read_response()` returns whatever is at the front. One orphaned frame therefore shifts every subsequent read by one, permanently. `drain_notifications()` mitigates this before each write, but it only clears what has *already* arrived.

Two gaps let stray frames through, both observed in the field:

**1. Frames survived a disconnect.** `disconnect()` cleared `_client` and `_notification_characteristic` but left the queue populated. A `BLEConnection` is reusable (`connect()` after a drop keeps the same queue), so residue from a dead link could be returned as the first response on the next link. Neither the stack-signalled drop nor the connect-retry teardown flushed either.

**2. A config read absorbed foreign frames silently.** `strip_command_echo()` returns a non-matching frame *unchanged*, so in `interrogate()` a frame from another exchange had its 2-byte echo consumed as the chunk-number field and its body appended as config data. The chunk loop only counts bytes, so nothing detected it.

Observed downstream, from a single session's logs:

```
First chunk: 98 bytes, total length: 707
Received chunk, total: 190/707
...
Received chunk, total: 766/707        <- 59 bytes over
Received complete TLV data: 766 bytes
WARNING Unknown packet type 0x00 at offset 128, skipping
```

`total_length` (707) matched the TLV wrapper's own length field; the extra 59 bytes were a stray frame spliced in, and the parser ran off the end of the real config into it. The same root cause surfaces elsewhere as a hard failure, e.g. `Firmware version echo mismatch: expected 0x0043, got 0x0040` — a leaked config chunk answering the firmware-version read.

## Changes

**Flush the queue on every disconnect path** — all three, only one of which goes through `disconnect()`:

- `_on_disconnect()`, the stack-signalled callback, is the only path that runs on an unexpected drop. Flushes before notifying the owner so it still runs if that callback raises.
- `disconnect()` flushes outside its `is_connected` branch — the branch is skipped when the link already died, and not all bleak backends invoke `disconnected_callback` for a caller-initiated disconnect.
- `_clear_cache_and_drop()` drops the client directly rather than via `disconnect()`, and a retried connect reuses the queue.

**Screen config-read frames by command echo.** `interrogate()` now skips frames belonging to other exchanges rather than splicing them in, bounded by `MAX_STRAY_CONFIG_FRAMES` so a device streaming unrelated frames fails with a clear error instead of renewing the read timeout indefinitely. The no-config NACK (`{0xFF,0x40,...}`) is passed through rather than skipped — it answers this command, and discarding it would turn a clear "no stored configuration" error into a timeout.

`strip_command_echo()` keeps its lenient behavior (callers that cannot receive foreign frames rely on it); the mismatch case is now documented and factored into `matches_command_echo()` for callers that must screen first.

**Name the command when a frame is dropped**, at both drop sites. `describe_command_code()` resolves the ACK high bit and the `0xFF` NACK prefix back to the originating command, so the frames most worth diagnosing don't log as unrecognized codes:

```
Ignoring stray READ_FW_VERSION (0x0043) frame (25 B) while reading config
Discarded 2 stale notification(s) before command: READ_CONFIG (0x0040) (4 B), AUTHENTICATE (0x0050) (3 B)
```

A bare count reported that a desync happened but not why.

## Notes

- No behavior change to `strip_command_echo()` itself, so no other call site is affected — it has only the two in `interrogate()`.
- Not addressed here: `interrogate()` still discards the chunk-number field without validating it, and never truncates `tlv_data` to `total_length`, so a *correctly-echoed* duplicate or overshooting final chunk can still get through. Happy to follow up separately.

## Test plan

- 9 new unit tests: disconnect/link-drop/connect-retry flush, owner still notified after flush, stray-frame skip, stray bound, error frame after a stray, ACK/NACK/unknown code labelling.
- Full suite: 1028 passed.
- `ruff`, `ruff-format`, `mypy --strict`, `pylint` clean via `prek run --all-files`.